### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
-on: 
-  pull_request:
-  push:
+on:
+ pull_request:
+ push:
+   branches:
     - main
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on: 
+  pull_request:
+  push:
+    - main
 
 defaults:
   run:


### PR DESCRIPTION
`on: push` only works if you push to the repo and not make a pull request from a fork.