### PR TITLE
Use pypa/cibuildwheel action

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build wheel
-        run: pip wheel -w wheelhouse .
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.0
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Use the `pypa/cibuildwheel` action instead of calling `pip wheel` manually. 