### PR TITLE
Don't build wheels of dependencies

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheel
-        run: pip wheel -w wheelhouse .
+        run: pip wheel --no-deps -w wheelhouse .
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
We either don't build the wheels in the first place or we later filter which wheels we try to push to PyPI. This seems like the cleaner way to go. 