### PR TITLE
Add more guards for `build` args

### DIFF
--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -105,7 +105,8 @@ def build(inputs: Dict[str, Var], outputs: Dict[str, Var]) -> onnx.ModelProto:
         )
     if not all(isinstance(var._op, Argument) for var in inputs.values()):
         raise TypeError(
-            "Build inputs must be argument Vars, and not results of other operations."
+            "Build inputs must be `Var`s constructed using the `spox.argument` function. "
+            "They must not be results of other operations."
         )
     if not outputs:
         raise ValueError("Build outputs must not be empty for the graph to be valid.")

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -9,7 +9,7 @@ from onnx.numpy_helper import to_array
 
 from . import _internal_op
 from ._attributes import AttrType
-from ._graph import results
+from ._graph import Argument, results
 from ._inline import _Inline
 from ._type_system import Type
 from ._var import Var
@@ -102,6 +102,10 @@ def build(inputs: Dict[str, Var], outputs: Dict[str, Var]) -> onnx.ModelProto:
     if not all(isinstance(var, Var) for var in outputs.values()):
         raise TypeError(
             f"Build outputs must be Vars, not {set(type(obj) for obj in outputs.values()) - {Var} }."
+        )
+    if not all(isinstance(var._op, Argument) for var in inputs.values()):
+        raise TypeError(
+            "Build inputs must be argument Vars, and not results of other operations."
         )
 
     with _temporary_renames(**inputs):

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -107,6 +107,8 @@ def build(inputs: Dict[str, Var], outputs: Dict[str, Var]) -> onnx.ModelProto:
         raise TypeError(
             "Build inputs must be argument Vars, and not results of other operations."
         )
+    if not outputs:
+        raise ValueError("Build outputs must not be empty for the graph to be valid.")
 
     with _temporary_renames(**inputs):
         graph = results(**outputs)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -20,6 +20,35 @@ def test_simple_build(simple_model):
     ) == np.array(17.0)
 
 
+def test_build_no_outputs_raises():
+    with pytest.raises(Exception):
+        build({"x": argument(Tensor(float, ()))}, {})
+
+
+def test_build_inputs_not_vars_raises():
+    x, y = argument(Tensor(float, ())), argument(Tensor(float, ()))
+    with pytest.raises(TypeError):
+        build({"x": x, "y": y}, {"z": None})  # type: ignore
+    with pytest.raises(TypeError):
+        build({"x": x, "y": y}, {"z": [op.add(x, y)]})  # type: ignore
+
+
+def test_build_outputs_not_vars_raises():
+    x, y = argument(Tensor(float, ())), argument(Tensor(float, ()))
+    with pytest.raises(TypeError):
+        build({"x": x, "y": y, "z": None}, {"z": op.add(x, y)})  # type: ignore
+    with pytest.raises(TypeError):
+        build({"x": x, "y": y, "xs": [x]}, {"z": op.add(x, y)})  # type: ignore
+
+
+def test_build_inputs_not_arguments_raises():
+    x, y = argument(Tensor(float, ())), argument(Tensor(float, ()))
+    with pytest.raises(TypeError):
+        build({"x": x, "y": op.add(x, y)}, {"z": op.add(x, y)})
+    with pytest.raises(TypeError):
+        build({"x": x, "y": y, "t": op.const(1)}, {"z": op.add(x, y)})
+
+
 def test_simple_inline(simple_model):
     a, b = argument(Tensor(float, ())), argument(Tensor(float, ()))
     (c,) = inline(simple_model)(a, y=b).values()


### PR DESCRIPTION
This is a small improvement that ensures build inputs are actually arguments, instead of other results. This caused a nasty error (`ScopeError`) before. It also checks that the `outputs` are non-empty. Several tests are added to ensure these (and other) invalidations raise.