### PR TITLE
Improve warning for dropping invalid prop value

### DIFF
--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -245,7 +245,7 @@ class Node(ABC):
                 else:
                     warnings.warn(
                         InferenceWarning(
-                            f"PropValue of {prop} does not type-check, dropping. "
+                            f"Propagated value {prop} does not type-check, dropping. "
                             f"Hint: this indicates a bug with the current value prop backend or type inference."
                         )
                     )

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -245,7 +245,8 @@ class Node(ABC):
                 else:
                     warnings.warn(
                         InferenceWarning(
-                            f"PropValue of {prop.type} does not match the expected type {prop.type}, dropping."
+                            f"PropValue of {prop} does not type-check, dropping. "
+                            f"Hint: this indicates a bug with the current value prop backend or type inference."
                         )
                     )
 


### PR DESCRIPTION
Tiny change that fixes a warning message in the case a propagated value does not type-check as expected. This is usually due to a bugged backend interpretation _or_ bad type inference. Propagating such a value could break type inference, so it is dropped - and a bug report should likely be filed against the implementation.