### PR TITLE
Fix inline not renaming unused model input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change log
 
 - The previously available ``Type <= Type`` (``Type.__le__``) overload is deprecated and will be removed in Spox ``0.7.0``, as it was unintentionally public.
 
+**Bug fixes**
+
+- ``spox.inline`` now correctly renames unused model inputs when building. This could previously cause invalid models to be built.
 
 0.6.1 (2023-03-07)
 ------------------

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -88,10 +88,18 @@ class _Inline(_InternalNode):
         # FIXME: This is a bug upstream - when add_prefix_graph has rename_edges,
         #        unused inputs are not renamed. We need 2 separate calls to fix this.
         if name is not None:
-            # graph = onnx.compose.add_prefix_graph(
-            #     self.graph, f"{name}__", rename_nodes=False, rename_edges=False, rename_inputs=True, rename_outputs=False, rename_initializers=True, rename_value_infos=False)
             graph = onnx.compose.add_prefix_graph(
-                self.graph, f"{name}__", rename_inputs=False
+                self.graph,
+                f"{name}__",
+                rename_nodes=False,
+                rename_edges=False,
+                rename_inputs=True,
+                rename_outputs=False,
+                rename_initializers=True,
+                rename_value_infos=False,
+            )
+            graph = onnx.compose.add_prefix_graph(
+                graph, f"{name}__", rename_inputs=False
             )
         else:
             graph = self.graph

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -101,9 +101,6 @@ class _Inline(_InternalNode):
             graph = onnx.compose.add_prefix_graph(graph, f"{name}__")
             for _ in graph.input:
                 graph.node.pop()
-            graph = onnx.compose.add_prefix_graph(
-                graph, f"{name}__", rename_inputs=False
-            )
         else:
             graph = self.graph
         nodes: List[onnx.NodeProto] = []

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -85,11 +85,16 @@ class _Inline(_InternalNode):
     ) -> List[onnx.NodeProto]:
         # Prefix all names in the graph to try and avoid name clashes
         name = scope.node[self] if self in scope.node else None
-        graph = (
-            onnx.compose.add_prefix_graph(self.graph, f"{name}__")
-            if name is not None
-            else self.graph
-        )
+        # FIXME: This is a bug upstream - when add_prefix_graph has rename_edges,
+        #        unused inputs are not renamed. We need 2 separate calls to fix this.
+        if name is not None:
+            # graph = onnx.compose.add_prefix_graph(
+            #     self.graph, f"{name}__", rename_nodes=False, rename_edges=False, rename_inputs=True, rename_outputs=False, rename_initializers=True, rename_value_infos=False)
+            graph = onnx.compose.add_prefix_graph(
+                self.graph, f"{name}__", rename_inputs=False
+            )
+        else:
+            graph = self.graph
         nodes: List[onnx.NodeProto] = []
         # Move initializers to Constant nodes
         input_names = {i.name for i in graph.input}


### PR DESCRIPTION
`onnx.compose.add_prefix_graph`, used by `spox.inline` to avoid name collisions, fails to rename unused model inputs when also renaming edges (due to taking a trivial if-branch possibly placed there for 'performance'?). This PR adds more tests to check our robustness on these cases, and applies a workaround to this bug by performing a two-stage rename (only renaming inputs explicitly at first).

_Side note:_ inline still does not have _truly_ unique names and prefixing is really just a hack. To get unique names (like in the rest of the code) we'd have to reimplement a raw-graph-renaming utility and then collect names not present in the current scope. This might require some intervention in the build code.