### PR TITLE
Fix dependencies with new package versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - nbsphinx
   - numpydoc
   - onnxruntime>=1.13.1
-  - pandoc  # ONNX docstrings in opset generation
+  - pandoc<=2.19.2  # ONNX docstrings in opset generation
   - pip
   - pre-commit
   - pytest-cov

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -292,7 +292,7 @@ def test_scan_for_product(op, onnx_helper):
 
 def test_sequence_map_for_zip_mul(op, onnx_helper):
     xs, ys = arguments(
-        xs=Sequence(Tensor(numpy.int32)), ys=Sequence(Tensor(numpy.int32))
+        xs=Sequence(Tensor(numpy.int64)), ys=Sequence(Tensor(numpy.int64))
     )
     (zs,) = op.sequence_map(xs, [ys], body=lambda x, y: (op.mul(x, y),))
     onnx_helper.assert_close(


### PR DESCRIPTION
Looks like conda has had some package updates which made ORT reveal a (sort of) bad test case in Spox. There's also a problem with pandoc seemingly?
