### PR TITLE
Fix test warnings caused by pending const change

### DIFF
--- a/tests/future/test_var_operators.py
+++ b/tests/future/test_var_operators.py
@@ -30,7 +30,7 @@ def test_arithmetic(bin_op, x, y):
 def test_arithmetic_mismatching_types():
     with operator_overloading(op, type_promotion=False):
         with pytest.raises(TypeError):
-            op.const(1) + op.const(2.0)
+            op.const(1) + op.const(np.float32(2.0))
 
 
 def test_var_neg():

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -7,7 +7,7 @@ from spox._type_system import Tensor
 
 def test_explicit_unspecified_optional(op, onnx_helper):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
-    r = op.clip(x, min=None, max=op.const(0.0))
+    r = op.clip(x, min=None, max=op.constant(value_float=0.0))
     graph = results(r=r)
     onnx_helper.assert_close(
         onnx_helper.run(graph, "r", x=numpy.array([-1, 1, 2], numpy.float32)),
@@ -17,8 +17,8 @@ def test_explicit_unspecified_optional(op, onnx_helper):
 
 def test_unspecified_optional(op, onnx_helper):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
-    r = op.clip(x, max=op.const(1.0))
-    r = op.clip(r, min=op.const(-1.0))
+    r = op.clip(x, max=op.constant(value_float=1.0))
+    r = op.clip(r, min=op.constant(value_float=-1.0))
     graph = results(r=r)
     onnx_helper.assert_close(
         onnx_helper.run(graph, "r", x=numpy.array([-3, -1, 1, 2], numpy.float32)),

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -80,7 +80,9 @@ def min_graph(op, lin_fun_proto):
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
-    (result,) = inline(lin_fun_proto)(A=first, X=op.const(1.0), B=second).values()
+    (result,) = inline(lin_fun_proto)(
+        A=first, X=op.constant(value_float=1.0), B=second
+    ).values()
     return results(final=result)
 
 
@@ -103,7 +105,7 @@ def larger_graph(op, lin_fun_proto):
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
     (result,) = inline(lin_fun_proto)(
-        A=op.add(first, second), X=op.const(2.0), B=second
+        A=op.add(first, second), X=op.constant(value_float=2.0), B=second
     ).values()
     return results(final=op.div(result, first))
 
@@ -172,6 +174,6 @@ def test_inc3_value_prop(op, inc_proto):
     def inc(s):
         return inline(inc_proto)(X=s)["Y"]
 
-    assert inc(inc(inc(op.const([0.0]))))._get_value() == numpy.array(
+    assert inc(inc(inc(op.constant(value_floats=[0.0]))))._get_value() == numpy.array(
         [3.0], numpy.float32
     )

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -10,7 +10,7 @@ from spox.opset.ai.onnx import v17 as op
 @pytest.fixture
 def simple_model():
     x, y = argument(Tensor(float, ())), argument(Tensor(float, ()))
-    z = op.add(x, op.mul(y, op.cast(op.const(2.0), to=float)))
+    z = op.add(x, op.mul(y, op.cast(op.constant(value_float=2.0), to=float)))
     return build({"x": x, "y": y}, {"z": z})
 
 

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -25,11 +25,15 @@ def test_variadic_output_inference(op):
 
 def test_optional_input_inference(op):
     (x,) = arguments(x=Tensor(numpy.float32, ("N",)))
-    assert op.clip(x, max=op.const(1.0)).type == Tensor(numpy.float32, ("N",))
-    assert op.clip(x, min=op.const(0.0)).type == Tensor(numpy.float32, ("N",))
-    assert op.clip(x, min=op.const(0.0), max=op.const(1.0)).type == Tensor(
+    assert op.clip(x, max=op.constant(value_float=1.0)).type == Tensor(
         numpy.float32, ("N",)
     )
+    assert op.clip(x, min=op.constant(value_float=0.0)).type == Tensor(
+        numpy.float32, ("N",)
+    )
+    assert op.clip(
+        x, min=op.constant(value_float=0.0), max=op.constant(value_float=1.0)
+    ).type == Tensor(numpy.float32, ("N",))
 
 
 def test_function_body_inference(op):

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -8,7 +8,7 @@ from spox._type_system import Sequence, Tensor
 def test_subgraph(op, onnx_helper):
     (e,) = arguments(e=Tensor(numpy.int64, ()))
     lp, sc = op.loop(
-        v_initial=[op.const([0.0])],  # Initial carry
+        v_initial=[op.constant(value_floats=[0.0])],  # Initial carry
         body=lambda iter_num, cond_in, carry_in: (
             # Stop condition: iter_num < e
             op.less(iter_num, e),
@@ -224,9 +224,8 @@ def test_copied_outer_argument(op, onnx_helper):
 
 def test_outer_scope_argument_used_only_inner(op, onnx_helper):
     b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
-    (r,) = op.if_(
-        b, else_branch=lambda: [x], then_branch=lambda: [op.mul(op.const(2.0), x)]
-    )
+    two = op.const(numpy.float32(2.0))
+    (r,) = op.if_(b, else_branch=lambda: [x], then_branch=lambda: [op.mul(two, x)])
     graph = results(r=r)
     onnx_helper.assert_close(
         onnx_helper.run(
@@ -292,7 +291,7 @@ def test_scan_for_product(op, onnx_helper):
 
 def test_sequence_map_for_zip_mul(op, onnx_helper):
     xs, ys = arguments(
-        xs=Sequence(Tensor(numpy.int32)), ys=Sequence(Tensor(numpy.int32))
+        xs=Sequence(Tensor(numpy.int64)), ys=Sequence(Tensor(numpy.int64))
     )
     (zs,) = op.sequence_map(xs, [ys], body=lambda x, y: (op.mul(x, y),))
     onnx_helper.assert_close(

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -66,7 +66,10 @@ def test_add(op):
 
 
 def test_div(op):
-    assert_equal_value(op.div(op.const(5.0), op.const(2.0)), numpy.float32(2.5))
+    assert_equal_value(
+        op.div(op.const(numpy.float32(5.0)), op.const(numpy.float32(2.0))),
+        numpy.float32(2.5),
+    )
 
 
 def test_identity(op):
@@ -86,7 +89,7 @@ def test_reshape(op):
 
 
 def test_optional(op):
-    assert_equal_value(op.optional(op.const(2.0)), numpy.float32(2.0))
+    assert_equal_value(op.optional(op.const(numpy.float32(2.0))), numpy.float32(2.0))
 
 
 def test_empty_optional(op):


### PR DESCRIPTION
This PR fixes warnings for `const` in the test suite as introduced in `0.6.1`. It uses a disambiguated form to get a `float32` constant.