### PR TITLE
Implementation attempt - hybrid variadic argument passing

### DIFF
--- a/src/spox/opset/ai/onnx/ml/v3.py
+++ b/src/spox/opset/ai/onnx/ml/v3.py
@@ -916,8 +916,8 @@ def dict_vectorizer(
 
 
 def feature_vectorizer(
-    X: Sequence[Var],
-    *,
+    X: Union[Var, Iterable[Var]],
+    *args: Var,
     inputdimensions: Optional[Iterable[int]] = None,
 ) -> Var:
     r"""
@@ -949,6 +949,15 @@ def feature_vectorizer(
     Type constraints:
      - T1: `tensor(double)`, `tensor(float)`, `tensor(int32)`, `tensor(int64)`
     """
+    if isinstance(X, Var):
+        X = (X,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input X is an iterable, no args should be passed."
+            )
+        X = tuple(X)
+    assert not isinstance(X, Var) and isinstance(X, Sequence)
     return _FeatureVectorizer(
         _FeatureVectorizer.Attributes(
             inputdimensions=AttrInt64s.maybe(inputdimensions),

--- a/src/spox/opset/ai/onnx/ml/v3.py
+++ b/src/spox/opset/ai/onnx/ml/v3.py
@@ -957,7 +957,7 @@ def feature_vectorizer(
     else:
         if args:
             raise ValueError(
-                "When the variadic input X is an iterable, no args should be passed."
+                "When the variadic input 'X' is an iterable, no args should be passed."
             )
         X = tuple(X)
     assert not isinstance(X, Var) and isinstance(X, Sequence)

--- a/src/spox/opset/ai/onnx/ml/v3.py
+++ b/src/spox/opset/ai/onnx/ml/v3.py
@@ -932,6 +932,9 @@ def feature_vectorizer(
     X
         Type T1.
         An ordered collection of tensors, all with the same element type.
+    args
+        The previous argument, X, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
     inputdimensions
         Attribute.
         The size of each input in the input list

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -5211,7 +5211,7 @@ def concat(
     else:
         if args:
             raise ValueError(
-                "When the variadic input inputs is an iterable, no args should be passed."
+                "When the variadic input 'inputs' is an iterable, no args should be passed."
             )
         inputs = tuple(inputs)
     assert not isinstance(inputs, Var) and isinstance(inputs, Sequence)
@@ -6453,7 +6453,7 @@ def einsum(
     else:
         if args:
             raise ValueError(
-                "When the variadic input Inputs is an iterable, no args should be passed."
+                "When the variadic input 'Inputs' is an iterable, no args should be passed."
             )
         Inputs = tuple(Inputs)
     assert not isinstance(Inputs, Var) and isinstance(Inputs, Sequence)
@@ -9111,7 +9111,7 @@ def loop(
     else:
         if args:
             raise ValueError(
-                "When the variadic input v_initial is an iterable, no args should be passed."
+                "When the variadic input 'v_initial' is an iterable, no args should be passed."
             )
         v_initial = tuple(v_initial)
     assert not isinstance(v_initial, Var) and isinstance(v_initial, Sequence)
@@ -9403,7 +9403,7 @@ def max(
     else:
         if args:
             raise ValueError(
-                "When the variadic input data_0 is an iterable, no args should be passed."
+                "When the variadic input 'data_0' is an iterable, no args should be passed."
             )
         data_0 = tuple(data_0)
     assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
@@ -9764,7 +9764,7 @@ def mean(
     else:
         if args:
             raise ValueError(
-                "When the variadic input data_0 is an iterable, no args should be passed."
+                "When the variadic input 'data_0' is an iterable, no args should be passed."
             )
         data_0 = tuple(data_0)
     assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
@@ -9947,7 +9947,7 @@ def min(
     else:
         if args:
             raise ValueError(
-                "When the variadic input data_0 is an iterable, no args should be passed."
+                "When the variadic input 'data_0' is an iterable, no args should be passed."
             )
         data_0 = tuple(data_0)
     assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
@@ -13097,7 +13097,7 @@ def scan(
     else:
         if args:
             raise ValueError(
-                "When the variadic input initial_state_and_scan_inputs is an iterable, no args should be passed."
+                "When the variadic input 'initial_state_and_scan_inputs' is an iterable, no args should be passed."
             )
         initial_state_and_scan_inputs = tuple(initial_state_and_scan_inputs)
     assert not isinstance(initial_state_and_scan_inputs, Var) and isinstance(
@@ -13633,7 +13633,7 @@ def sequence_construct(
     else:
         if args:
             raise ValueError(
-                "When the variadic input inputs is an iterable, no args should be passed."
+                "When the variadic input 'inputs' is an iterable, no args should be passed."
             )
         inputs = tuple(inputs)
     assert not isinstance(inputs, Var) and isinstance(inputs, Sequence)
@@ -13877,7 +13877,7 @@ def sequence_map(
     else:
         if args:
             raise ValueError(
-                "When the variadic input additional_inputs is an iterable, no args should be passed."
+                "When the variadic input 'additional_inputs' is an iterable, no args should be passed."
             )
         additional_inputs = tuple(additional_inputs)
     assert not isinstance(additional_inputs, Var) and isinstance(
@@ -14900,7 +14900,7 @@ def sum(
     else:
         if args:
             raise ValueError(
-                "When the variadic input data_0 is an iterable, no args should be passed."
+                "When the variadic input 'data_0' is an iterable, no args should be passed."
             )
         data_0 = tuple(data_0)
     assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -5171,8 +5171,8 @@ def compress(
 
 
 def concat(
-    inputs: Sequence[Var],
-    *,
+    inputs: Union[Var, Iterable[Var]],
+    *args: Var,
     axis: int,
 ) -> Var:
     r"""
@@ -5203,6 +5203,15 @@ def concat(
     Type constraints:
      - T: `tensor(bfloat16)`, `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(inputs, Var):
+        inputs = (inputs,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input inputs is an iterable, no args should be passed."
+            )
+        inputs = tuple(inputs)
+    assert not isinstance(inputs, Var) and isinstance(inputs, Sequence)
     return _Concat(
         _Concat.Attributes(
             axis=AttrInt64(axis),
@@ -6374,8 +6383,8 @@ def dynamic_quantize_linear(
 
 
 def einsum(
-    Inputs: Sequence[Var],
-    *,
+    Inputs: Union[Var, Iterable[Var]],
+    *args: Var,
     equation: str,
 ) -> Var:
     r"""
@@ -6433,6 +6442,15 @@ def einsum(
     Type constraints:
      - T: `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(Inputs, Var):
+        Inputs = (Inputs,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input Inputs is an iterable, no args should be passed."
+            )
+        Inputs = tuple(Inputs)
+    assert not isinstance(Inputs, Var) and isinstance(Inputs, Sequence)
     return _Einsum(
         _Einsum.Attributes(
             equation=AttrString(equation),
@@ -8890,8 +8908,8 @@ def log_softmax(
 def loop(
     M: Optional[Var] = None,
     cond: Optional[Var] = None,
-    v_initial: Sequence[Var] = (),
-    *,
+    v_initial: Union[Var, Iterable[Var]] = (),
+    *args: Var,
     body: Callable[..., Iterable[Var]],
 ) -> Sequence[Var]:
     r"""
@@ -9079,6 +9097,15 @@ def loop(
      - B: `tensor(bool)`
      - V: `optional(seq(tensor(bfloat16)))`, `optional(seq(tensor(bool)))`, `optional(seq(tensor(complex128)))`, `optional(seq(tensor(complex64)))`, `optional(seq(tensor(double)))`, `optional(seq(tensor(float)))`, `optional(seq(tensor(float16)))`, `optional(seq(tensor(int16)))`, `optional(seq(tensor(int32)))`, `optional(seq(tensor(int64)))`, `optional(seq(tensor(int8)))`, `optional(seq(tensor(string)))`, `optional(seq(tensor(uint16)))`, `optional(seq(tensor(uint32)))`, `optional(seq(tensor(uint64)))`, `optional(seq(tensor(uint8)))`, `optional(tensor(bfloat16))`, `optional(tensor(bool))`, `optional(tensor(complex128))`, `optional(tensor(complex64))`, `optional(tensor(double))`, `optional(tensor(float))`, `optional(tensor(float16))`, `optional(tensor(int16))`, `optional(tensor(int32))`, `optional(tensor(int64))`, `optional(tensor(int8))`, `optional(tensor(string))`, `optional(tensor(uint16))`, `optional(tensor(uint32))`, `optional(tensor(uint64))`, `optional(tensor(uint8))`, `seq(tensor(bfloat16))`, `seq(tensor(bool))`, `seq(tensor(complex128))`, `seq(tensor(complex64))`, `seq(tensor(double))`, `seq(tensor(float))`, `seq(tensor(float16))`, `seq(tensor(int16))`, `seq(tensor(int32))`, `seq(tensor(int64))`, `seq(tensor(int8))`, `seq(tensor(string))`, `seq(tensor(uint16))`, `seq(tensor(uint32))`, `seq(tensor(uint64))`, `seq(tensor(uint8))`, `tensor(bfloat16)`, `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(v_initial, Var):
+        v_initial = (v_initial,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input v_initial is an iterable, no args should be passed."
+            )
+        v_initial = tuple(v_initial)
+    assert not isinstance(v_initial, Var) and isinstance(v_initial, Sequence)
     _body_subgraph: Graph = subgraph(
         typing_cast(List[Type], [Tensor(np.int64, (1,)), Tensor(np.bool_, (1,))])
         + [var.unwrap_type() for var in v_initial],
@@ -9330,7 +9357,8 @@ def matmul_integer(
 
 
 def max(
-    data_0: Sequence[Var],
+    data_0: Union[Var, Iterable[Var]],
+    *args: Var,
 ) -> Var:
     r"""
     Element-wise max of each of the input tensors (with Numpy-style
@@ -9358,6 +9386,15 @@ def max(
     Type constraints:
      - T: `tensor(bfloat16)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(data_0, Var):
+        data_0 = (data_0,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input data_0 is an iterable, no args should be passed."
+            )
+        data_0 = tuple(data_0)
+    assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
     return _Max(
         _Max.Attributes(),
         _Max.Inputs(
@@ -9678,7 +9715,8 @@ def max_unpool(
 
 
 def mean(
-    data_0: Sequence[Var],
+    data_0: Union[Var, Iterable[Var]],
+    *args: Var,
 ) -> Var:
     r"""
     Element-wise mean of each of the input tensors (with Numpy-style
@@ -9706,6 +9744,15 @@ def mean(
     Type constraints:
      - T: `tensor(bfloat16)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`
     """
+    if isinstance(data_0, Var):
+        data_0 = (data_0,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input data_0 is an iterable, no args should be passed."
+            )
+        data_0 = tuple(data_0)
+    assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
     return _Mean(
         _Mean.Attributes(),
         _Mean.Inputs(
@@ -9848,7 +9895,8 @@ def mel_weight_matrix(
 
 
 def min(
-    data_0: Sequence[Var],
+    data_0: Union[Var, Iterable[Var]],
+    *args: Var,
 ) -> Var:
     r"""
     Element-wise min of each of the input tensors (with Numpy-style
@@ -9876,6 +9924,15 @@ def min(
     Type constraints:
      - T: `tensor(bfloat16)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(data_0, Var):
+        data_0 = (data_0,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input data_0 is an iterable, no args should be passed."
+            )
+        data_0 = tuple(data_0)
+    assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
     return _Min(
         _Min.Attributes(),
         _Min.Inputs(
@@ -12808,8 +12865,8 @@ def stft(
 
 
 def scan(
-    initial_state_and_scan_inputs: Sequence[Var],
-    *,
+    initial_state_and_scan_inputs: Union[Var, Iterable[Var]],
+    *args: Var,
     body: Callable[..., Iterable[Var]],
     num_scan_inputs: int,
     scan_input_axes: Optional[Iterable[int]] = None,
@@ -13014,6 +13071,17 @@ def scan(
     Type constraints:
      - V: `tensor(bfloat16)`, `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(initial_state_and_scan_inputs, Var):
+        initial_state_and_scan_inputs = (initial_state_and_scan_inputs,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input initial_state_and_scan_inputs is an iterable, no args should be passed."
+            )
+        initial_state_and_scan_inputs = tuple(initial_state_and_scan_inputs)
+    assert not isinstance(initial_state_and_scan_inputs, Var) and isinstance(
+        initial_state_and_scan_inputs, Sequence
+    )
     _body_subgraph: Graph = subgraph(
         [
             Tensor(
@@ -13509,7 +13577,8 @@ def sequence_at(
 
 
 def sequence_construct(
-    inputs: Sequence[Var],
+    inputs: Union[Var, Iterable[Var]],
+    *args: Var,
 ) -> Var:
     r"""
     Construct a tensor sequence containing 'inputs' tensors. All tensors in
@@ -13535,6 +13604,15 @@ def sequence_construct(
      - T: `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
      - S: `seq(tensor(bool))`, `seq(tensor(complex128))`, `seq(tensor(complex64))`, `seq(tensor(double))`, `seq(tensor(float))`, `seq(tensor(float16))`, `seq(tensor(int16))`, `seq(tensor(int32))`, `seq(tensor(int64))`, `seq(tensor(int8))`, `seq(tensor(string))`, `seq(tensor(uint16))`, `seq(tensor(uint32))`, `seq(tensor(uint64))`, `seq(tensor(uint8))`
     """
+    if isinstance(inputs, Var):
+        inputs = (inputs,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input inputs is an iterable, no args should be passed."
+            )
+        inputs = tuple(inputs)
+    assert not isinstance(inputs, Var) and isinstance(inputs, Sequence)
     return _SequenceConstruct(
         _SequenceConstruct.Attributes(),
         _SequenceConstruct.Inputs(
@@ -13717,8 +13795,8 @@ def sequence_length(
 
 def sequence_map(
     input_sequence: Var,
-    additional_inputs: Sequence[Var] = (),
-    *,
+    additional_inputs: Union[Var, Iterable[Var]] = (),
+    *args: Var,
     body: Callable[..., Iterable[Var]],
 ) -> Sequence[Var]:
     r"""
@@ -13767,12 +13845,20 @@ def sequence_map(
      - S: `seq(tensor(bool))`, `seq(tensor(complex128))`, `seq(tensor(complex64))`, `seq(tensor(double))`, `seq(tensor(float))`, `seq(tensor(float16))`, `seq(tensor(int16))`, `seq(tensor(int32))`, `seq(tensor(int64))`, `seq(tensor(int8))`, `seq(tensor(string))`, `seq(tensor(uint16))`, `seq(tensor(uint32))`, `seq(tensor(uint64))`, `seq(tensor(uint8))`
      - V: `seq(tensor(bool))`, `seq(tensor(complex128))`, `seq(tensor(complex64))`, `seq(tensor(double))`, `seq(tensor(float))`, `seq(tensor(float16))`, `seq(tensor(int16))`, `seq(tensor(int32))`, `seq(tensor(int64))`, `seq(tensor(int8))`, `seq(tensor(string))`, `seq(tensor(uint16))`, `seq(tensor(uint32))`, `seq(tensor(uint64))`, `seq(tensor(uint8))`, `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    if isinstance(additional_inputs, Var):
+        additional_inputs = (additional_inputs,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input additional_inputs is an iterable, no args should be passed."
+            )
+        additional_inputs = tuple(additional_inputs)
+    assert not isinstance(additional_inputs, Var) and isinstance(
+        additional_inputs, Sequence
+    )
     _body_subgraph: Graph = subgraph(
-        [typing_cast(SpoxSequence, input_sequence.unwrap_type()).elem_type]
-        + [
-            typing_cast(SpoxSequence, var.unwrap_type()).elem_type
-            for var in additional_inputs
-        ],
+        [input_sequence.unwrap_sequence().elem_type]
+        + [var.unwrap_sequence().elem_type for var in additional_inputs],
         body,
     )
     return _SequenceMap(
@@ -14750,7 +14836,8 @@ def sub(
 
 
 def sum(
-    data_0: Sequence[Var],
+    data_0: Union[Var, Iterable[Var]],
+    *args: Var,
 ) -> Var:
     r"""
     Element-wise sum of each of the input tensors (with Numpy-style
@@ -14778,6 +14865,15 @@ def sum(
     Type constraints:
      - T: `tensor(bfloat16)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`
     """
+    if isinstance(data_0, Var):
+        data_0 = (data_0,) + args
+    else:
+        if args:
+            raise ValueError(
+                "When the variadic input data_0 is an iterable, no args should be passed."
+            )
+        data_0 = tuple(data_0)
+    assert not isinstance(data_0, Var) and isinstance(data_0, Sequence)
     return _Sum(
         _Sum.Attributes(),
         _Sum.Inputs(

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -5185,6 +5185,9 @@ def concat(
     inputs
         Type T.
         List of tensors for concatenation
+    args
+        The previous argument, inputs, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
     axis
         Attribute.
         Which axis to concat on. A negative value means counting dimensions from
@@ -6425,6 +6428,9 @@ def einsum(
     Inputs
         Type T.
         Operands
+    args
+        The previous argument, Inputs, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
     equation
         Attribute.
         Einsum expression string.
@@ -9071,6 +9077,9 @@ def loop(
         Type V.
         The initial values of any loop-carried dependencies (values that change
         across loop iterations)
+    args
+        The previous argument, v_initial, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
     body
         Attribute.
         The graph run each iteration. It has 2+N inputs: (iteration_num,
@@ -9372,6 +9381,9 @@ def max(
     data_0
         Type T.
         List of tensors for max.
+    args
+        The previous argument, data_0, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
 
     Returns
     =======
@@ -9730,6 +9742,9 @@ def mean(
     data_0
         Type T.
         List of tensors for mean.
+    args
+        The previous argument, data_0, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
 
     Returns
     =======
@@ -9910,6 +9925,9 @@ def min(
     data_0
         Type T.
         List of tensors for min.
+    args
+        The previous argument, data_0, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
 
     Returns
     =======
@@ -13019,6 +13037,9 @@ def scan(
     initial_state_and_scan_inputs
         Type V.
         Initial values of the loop's N state variables followed by M scan_inputs
+    args
+        The previous argument, initial_state_and_scan_inputs, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
     body
         Attribute.
         The graph run each iteration. It has N+M inputs: (loop state
@@ -13589,6 +13610,9 @@ def sequence_construct(
     inputs
         Type T.
         Tensors.
+    args
+        The previous argument, inputs, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
 
     Returns
     =======
@@ -13825,6 +13849,9 @@ def sequence_map(
     additional_inputs
         Type V.
         Additional inputs to the graph
+    args
+        The previous argument, additional_inputs, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
     body
         Attribute.
         The graph to be run for each sample in the sequence(s). It should have
@@ -14851,6 +14878,9 @@ def sum(
     data_0
         Type T.
         List of tensors for sum.
+    args
+        The previous argument, data_0, represents a variadic input.
+        This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
 
     Returns
     =======

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -34,6 +34,24 @@ def test_variadic_no_input_list_mutation(op, onnx_helper):
     assert list(concat._op.inputs) == [a, b]
 
 
+def test_variadic_as_iterable(op, onnx_helper):
+    a, b, c = op.const([1]), op.const([2]), op.const([3])
+    concat = op.concat([a, b, c], axis=0)
+    assert list(concat._op.inputs) == [a, b, c]
+
+
+def test_variadic_as_args(op, onnx_helper):
+    a, b, c = op.const([1]), op.const([2]), op.const([3])
+    concat = op.concat(a, b, c, axis=0)
+    assert list(concat._op.inputs) == [a, b, c]
+
+
+def test_variadic_mixed_raises(op, onnx_helper):
+    a, b, c = op.const([1]), op.const([2]), op.const([3])
+    with pytest.raises(ValueError):
+        op.concat([a, b], c, axis=0)
+
+
 def test_const_float_warns(op):
     with pytest.warns(DeprecationWarning):
         op.const(1.0)

--- a/tools/generate_opset.py
+++ b/tools/generate_opset.py
@@ -70,8 +70,8 @@ SCAN16_SUBGRAPH_SOLUTION = {
     "for var in initial_state_and_scan_inputs[num_scan_inputs:]]"
 }
 SEQUENCEMAP17_SUBGRAPH_SOLUTION = {
-    "body": "[typing_cast(SpoxSequence, input_sequence.unwrap_type()).elem_type] + "
-    "[typing_cast(SpoxSequence, var.unwrap_type()).elem_type for var in additional_inputs]"
+    "body": "[input_sequence.unwrap_sequence().elem_type] + "
+    "[var.unwrap_sequence().elem_type for var in additional_inputs]"
 }
 
 V16_OUT_VARIADIC_SOLUTIONS = {

--- a/tools/templates/construct.jinja2
+++ b/tools/templates/construct.jinja2
@@ -4,7 +4,7 @@ if isinstance({{ vararg }}, Var):
     {{ vararg }} = ({{ vararg }},) + args
 else:
     if args:
-        raise ValueError("When the variadic input {{ vararg }} is an iterable, no args should be passed.")
+        raise ValueError("When the variadic input '{{ vararg }}' is an iterable, no args should be passed.")
     {{ vararg }} = tuple({{ vararg }})
 assert not isinstance({{ vararg }}, Var) and isinstance({{ vararg }}, Sequence)
 {% endif %}

--- a/tools/templates/construct.jinja2
+++ b/tools/templates/construct.jinja2
@@ -1,3 +1,13 @@
+{% if schema.inputs and is_variadic(schema.inputs[-1]) %}
+{% set vararg = schema.inputs[-1].name %}
+if isinstance({{ vararg }}, Var):
+    {{ vararg }} = ({{ vararg }},) + args
+else:
+    if args:
+        raise ValueError("When the variadic input {{ vararg }} is an iterable, no args should be passed.")
+    {{ vararg }} = tuple({{ vararg }})
+assert not isinstance({{ vararg }}, Var) and isinstance({{ vararg }}, Sequence)
+{% endif %}
 {% for attr in attributes %}
     {% if attr.attr_constructor == "AttrGraph" %}
 _{{ attr.name }}_subgraph: Graph = subgraph(

--- a/tools/templates/constructor.jinja2
+++ b/tools/templates/constructor.jinja2
@@ -3,13 +3,15 @@ for param in schema.inputs %}{%
     if is_optional(param)
         %}{{ param.name }}: Optional[Var] = None, {%
     elif is_variadic(param)
-        %}{{ param.name }}: Sequence[Var]{{" = ()" if loop.index0 >= schema.min_input else ""}}, {%
+        %}{{ param.name }}: Union[Var, Iterable[Var]]{{" = ()" if loop.index0 >= schema.min_input else ""}}, {%
     else
         %}{{ param.name }}: Var, {%
-endif %}{% endfor %}
-    {% if schema.attributes
-        %}*, {%
-    endif %}{%
+endif %}{% endfor %}{%
+if schema.inputs and is_variadic(schema.inputs[-1])
+  %}*args: Var, {%
+elif schema.attributes
+    %}*, {%
+endif %}{%
 if is_variadic(schema.outputs[-1]) and not out_variadic_solution
     %}{{ schema.outputs[-1].name }}_count: int, {% endif %}
 {% for attr in attributes %}

--- a/tools/templates/docstring.jinja2
+++ b/tools/templates/docstring.jinja2
@@ -14,6 +14,11 @@ Parameters
 {{ param.description | format_github_markdown }}
 {% endfilter %}
 {% endfor %}
+{% if schema.inputs and is_variadic(schema.inputs[-1]) %}
+args
+    The previous argument, {{ schema.inputs[-1].name }}, represents a variadic input.
+    This function accepts it either as an ``Iterable[Var]`` or an ``*args: Var``.
+{% endif %}
 {% for attr in schema.attributes.values() %}
 {{ attr.name }}
 {% filter indent(width=4) %}


### PR DESCRIPTION
This is an attempt (second, actually) at implementing #37. I think this is the simplest implementation I can do and I'm not really happy with it.

A point that was not considered in the proposal directly is that we have been passing variadic arguments as keyword arguments, for instance when doing `op.loop(v_initial=[...], ...)`. This means that the variadic argument cannot be a Python variadic (`*args`), as then it cannot be passed by name. This limits our design space.

Hence, we need to have this sort of signatures (possibly limited by `@typing.overload`, but in general they would be this):

```py
def concat(
    inputs: Union[Var, Iterable[Var]],
    *args: Var,
    axis: int,
) -> Var:
    ...

def loop(
    M: Optional[Var] = None,
    cond: Optional[Var] = None,
    v_initial: Union[Var, Iterable[Var]] = (),
    *args: Var,
    body: Callable[..., Iterable[Var]],
) -> Sequence[Var]:
    ...

def sequence_map(
    input_sequence: Var,
    additional_inputs: Union[Var, Iterable[Var]] = (),
    *args: Var,
    body: Callable[..., Iterable[Var]],
) -> Sequence[Var]:
```

Where the variadic input of a name may stand for either an `Iterable[Var]` of the first of `Var`, the rest of which go into `*args`. This allows passing both in the style of `op.sequence_map(s1, s2, s3, ...)` and `op.concat([x, y, z])`.

However, I'm no longer sure any possible benefits of this are worth the uglier signature. The only use case I had in mind (programmatic constructor calls from ONNX input lists) can just use `inspect` to find there is a `Sequence` argument and the end, and pass to it explicitly.

What are your thoughts on scrapping #37 based on how this attempt turned out, @cbourjau ?