### PR TITLE
Ensure attributes are copied to avoid mutation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Change log
 
 - The previously available ``Type <= Type`` (``Type.__le__``) overload is deprecated and will be removed in Spox ``0.7.0``, as it was unintentionally public.
 
+**Bug fixes*
+
+- Array attributes are now copied when they are passed to an operator. This avoids accidentally mutating them after the operator is constructed.
 
 0.6.1 (2023-03-07)
 ------------------

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -79,6 +79,9 @@ class _Ref(Generic[T]):
         self._concrete = concrete
         self._outer_name = outer_name
 
+    def copy(self) -> "_Ref[T]":
+        return self
+
     def _to_onnx(self, key: str) -> AttributeProto:
         parent_type = self._concrete._to_onnx(key).type
         return AttributeProto(
@@ -112,6 +115,9 @@ class AttrString(Attr[str]):
 
 class AttrTensor(Attr[np.ndarray]):
     _attribute_proto_type_int = AttributeProto.TENSOR
+
+    def __init__(self, value: Union[np.ndarray, _Ref[np.ndarray]]):
+        super().__init__(value.copy())
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         return make_attribute(key, from_array(self.value))

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -34,6 +34,20 @@ def test_variadic_no_input_list_mutation(op, onnx_helper):
     assert list(concat._op.inputs) == [a, b]
 
 
+def test_variadic_no_attr_mutation_array(op, onnx_helper):
+    a = numpy.array([1])
+    x = op.constant(value=a)
+    a[0] = 0
+    assert list(x._op.attrs.value.value) == [1]
+
+
+def test_variadic_no_attr_mutation_list(op, onnx_helper):
+    a = [1]
+    x = op.constant(value_ints=a)
+    a[0] = 0
+    assert list(x._op.attrs.value_ints.value) == [1]
+
+
 def test_const_float_warns(op):
     with pytest.warns(DeprecationWarning):
         op.const(1.0)


### PR DESCRIPTION
Checks if they can't be mutated accidentally. There was a bug for array attributes (`AttrTensor`).