### PR TITLE
Raise a warning when a deprecated operator is used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change log
 **Pending breaking changes**
 
 - The previously available ``Type <= Type`` (``Type.__le__``) overload is deprecated and will be removed in Spox ``0.7.0``, as it was unintentionally public.
+- Constructors for deprecated ONNX operators (currently ``Scatter`` and ``Upsample``) now raise a warning when they are called. They will be removed entirely in ``0.7.0``.
 
 **Bug fixes**
 

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -13147,7 +13147,8 @@ def scatter(
     """
     warnings.warn(
         "Scatter is a deprecated operator and its constructor should not be used. "
-        "Deprecated constructors will be removed in Spox 0.7.0.",
+    "Building will raise an error. "
+    "Deprecated constructors will be removed in Spox 0.7.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -13145,6 +13145,12 @@ def scatter(
      - T: `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
      - Tind: `tensor(int32)`, `tensor(int64)`
     """
+    warnings.warn(
+        "Scatter is a deprecated operator and its constructor should not be used. "
+        "Deprecated constructors will be removed in Spox 0.7.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _Scatter(
         _Scatter.Attributes(
             axis=AttrInt64(axis),
@@ -15485,6 +15491,12 @@ def upsample(
     Type constraints:
      - T: `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
+    warnings.warn(
+        "Upsample is a deprecated operator and its constructor should not be used. "
+        "Deprecated constructors will be removed in Spox 0.7.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return _Upsample(
         _Upsample.Attributes(
             mode=AttrString(mode),

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -15494,7 +15494,8 @@ def upsample(
     """
     warnings.warn(
         "Upsample is a deprecated operator and its constructor should not be used. "
-        "Deprecated constructors will be removed in Spox 0.7.0.",
+    "Building will raise an error. "
+    "Deprecated constructors will be removed in Spox 0.7.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -13147,8 +13147,8 @@ def scatter(
     """
     warnings.warn(
         "Scatter is a deprecated operator and its constructor should not be used. "
-    "Building will raise an error. "
-    "Deprecated constructors will be removed in Spox 0.7.0.",
+        "Building will raise an error. "
+        "Deprecated constructors will be removed in Spox 0.7.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -15494,8 +15494,8 @@ def upsample(
     """
     warnings.warn(
         "Upsample is a deprecated operator and its constructor should not be used. "
-    "Building will raise an error. "
-    "Deprecated constructors will be removed in Spox 0.7.0.",
+        "Building will raise an error. "
+        "Deprecated constructors will be removed in Spox 0.7.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -57,7 +57,9 @@ def test_const_float_warns(op):
 
 def test_deprecated_raises(op):
     (x,) = arguments(x=Tensor(float, (None,)))
-    y = op.upsample(x, op.const(numpy.array([2.0], numpy.float32)))
+    s = op.const(numpy.array([2.0], numpy.float32))
+    with pytest.warns(DeprecationWarning):
+        y = op.upsample(x, s)
     graph = results(y=y).with_arguments(x)
     with pytest.raises(Exception):
         graph.to_onnx_model()

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -53,3 +53,11 @@ def test_const_float_warns(op):
         op.const(1.0)
     with pytest.warns(DeprecationWarning):
         op.const([1.0, 2.0, 3.0])
+
+
+def test_deprecated_raises(op):
+    (x,) = arguments(x=Tensor(float, (None,)))
+    y = op.upsample(x, op.const(numpy.array([2.0], numpy.float32)))
+    graph = results(y=y).with_arguments(x)
+    with pytest.raises(Exception):
+        graph.to_onnx_model()

--- a/tools/generate_opset.py
+++ b/tools/generate_opset.py
@@ -581,7 +581,11 @@ def main(
     onnx_domain = domain if domain != DEFAULT_DOMAIN else ""
     if version is None:
         version = max(DOMAIN_VERSIONS[onnx_domain])
-    schemas = list(SCHEMAS[onnx_domain][version].values())
+    schemas = [
+        schema
+        for schema in SCHEMAS[onnx_domain][version].values()
+        # if not schema.deprecated  # TODO: Do not generate deprecated schemas.
+    ]
 
     domain_path = "/".join(domain.split("."))
 

--- a/tools/templates/construct.jinja2
+++ b/tools/templates/construct.jinja2
@@ -1,7 +1,7 @@
 {% if schema.deprecated %}
 warnings.warn(
     "{{ schema.name }} is a deprecated operator and its constructor should not be used. "
-    "Deprecated constructors will no longer be generated in a future release."
+    "Deprecated constructors will be removed in Spox 0.7.0.",
     DeprecationWarning, stacklevel=2
 )
 {% endif %}

--- a/tools/templates/construct.jinja2
+++ b/tools/templates/construct.jinja2
@@ -1,6 +1,7 @@
 {% if schema.deprecated %}
 warnings.warn(
     "{{ schema.name }} is a deprecated operator and its constructor should not be used. "
+    "Building will raise an error. "
     "Deprecated constructors will be removed in Spox 0.7.0.",
     DeprecationWarning, stacklevel=2
 )

--- a/tools/templates/construct.jinja2
+++ b/tools/templates/construct.jinja2
@@ -1,3 +1,10 @@
+{% if schema.deprecated %}
+warnings.warn(
+    "{{ schema.name }} is a deprecated operator and its constructor should not be used. "
+    "Deprecated constructors will no longer be generated in a future release."
+    DeprecationWarning, stacklevel=2
+)
+{% endif %}
 {% for attr in attributes %}
     {% if attr.attr_constructor == "AttrGraph" %}
 _{{ attr.name }}_subgraph: Graph = subgraph(


### PR DESCRIPTION
This is a first step at #58. Warnings are raised when deprecated operators are used. See the issue for a description.