### PR TITLE
Remove the opset fixture in the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import numpy
 import onnxruntime
 import pytest
 
-import spox.opset.ai.onnx.v17
 from spox import _value_prop
 from spox._debug import show_construction_tracebacks
 from spox._graph import Graph
@@ -72,9 +71,3 @@ class ONNXRuntimeHelper:
 @pytest.fixture(scope="session")
 def onnx_helper():
     return ONNXRuntimeHelper()
-
-
-# Selects operator sets for testing
-@pytest.fixture(params=[spox.opset.ai.onnx.v17])
-def op(request):
-    return request.param

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -33,7 +33,7 @@ agraph (float[1, N] A) => (float[N] B)
 
 
 @pytest.fixture
-def inline_old_squeeze_graph(op, old_squeeze):
+def inline_old_squeeze_graph(old_squeeze):
     (data,) = arguments(
         data=Tensor(
             numpy.float32,
@@ -48,7 +48,7 @@ def inline_old_squeeze_graph(op, old_squeeze):
 
 
 @pytest.fixture
-def old_squeeze_graph(op, old_squeeze):
+def old_squeeze_graph(old_squeeze):
     class Squeeze11(StandardNode):
         @dataclass
         class Attributes(BaseAttributes):

--- a/tests/test_attr.py
+++ b/tests/test_attr.py
@@ -1,20 +1,21 @@
 import numpy as np
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._attributes import AttrString, AttrStrings, AttrTensor
 
 
-def test_bad_attribute_type_cast_fails(op):
+def test_bad_attribute_type_cast_fails():
     with pytest.raises(TypeError):
         # to must be an value which can be handled by `np.dtype`.
         op.cast(op.const(1), to="abc")
 
 
-def test_cast_with_build_in_type(op):
+def test_cast_with_build_in_type():
     op.cast(op.const(1), to=str)
 
 
-def test_float_instead_of_int_attr(op):
+def test_float_instead_of_int_attr():
     with pytest.raises(TypeError):
         op.concat([op.const(1)], axis=3.14)
 

--- a/tests/test_attr.py
+++ b/tests/test_attr.py
@@ -17,7 +17,7 @@ def test_cast_with_build_in_type():
 
 def test_float_instead_of_int_attr():
     with pytest.raises(TypeError):
-        op.concat([op.const(1)], axis=3.14)
+        op.concat([op.const(1)], axis=3.14)  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -1,11 +1,12 @@
 import numpy
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments, results
 from spox._type_system import Tensor
 
 
-def test_explicit_unspecified_optional(op, onnx_helper):
+def test_explicit_unspecified_optional(onnx_helper):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
     r = op.clip(x, min=None, max=op.constant(value_float=0.0))
     graph = results(r=r)
@@ -15,7 +16,7 @@ def test_explicit_unspecified_optional(op, onnx_helper):
     )
 
 
-def test_unspecified_optional(op, onnx_helper):
+def test_unspecified_optional(onnx_helper):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
     r = op.clip(x, max=op.constant(value_float=1.0))
     r = op.clip(r, min=op.constant(value_float=-1.0))
@@ -26,7 +27,7 @@ def test_unspecified_optional(op, onnx_helper):
     )
 
 
-def test_variadic_no_input_list_mutation(op, onnx_helper):
+def test_variadic_no_input_list_mutation(onnx_helper):
     a, b = op.const([1]), op.const([2])
     ins = [a, b]
     concat = op.concat(ins, axis=0)
@@ -34,28 +35,28 @@ def test_variadic_no_input_list_mutation(op, onnx_helper):
     assert list(concat._op.inputs) == [a, b]
 
 
-def test_variadic_no_attr_mutation_array(op, onnx_helper):
+def test_variadic_no_attr_mutation_array(onnx_helper):
     a = numpy.array([1])
     x = op.constant(value=a)
     a[0] = 0
     assert list(x._op.attrs.value.value) == [1]
 
 
-def test_variadic_no_attr_mutation_list(op, onnx_helper):
+def test_variadic_no_attr_mutation_list(onnx_helper):
     a = [1]
     x = op.constant(value_ints=a)
     a[0] = 0
     assert list(x._op.attrs.value_ints.value) == [1]
 
 
-def test_const_float_warns(op):
+def test_const_float_warns():
     with pytest.warns(DeprecationWarning):
         op.const(1.0)
     with pytest.warns(DeprecationWarning):
         op.const([1.0, 2.0, 3.0])
 
 
-def test_deprecated_raises(op):
+def test_deprecated_raises():
     (x,) = arguments(x=Tensor(float, (None,)))
     s = op.const(numpy.array([2.0], numpy.float32))
     with pytest.warns(DeprecationWarning):

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -39,6 +39,8 @@ def test_variadic_no_attr_mutation_array(onnx_helper):
     a = numpy.array([1])
     x = op.constant(value=a)
     a[0] = 0
+    assert isinstance(x._op, op._Constant)
+    assert x._op.attrs.value is not None
     assert list(x._op.attrs.value.value) == [1]
 
 
@@ -46,6 +48,8 @@ def test_variadic_no_attr_mutation_list(onnx_helper):
     a = [1]
     x = op.constant(value_ints=a)
     a[0] = 0
+    assert isinstance(x._op, op._Constant)
+    assert x._op.attrs.value_ints is not None
     assert list(x._op.attrs.value_ints.value) == [1]
 
 

--- a/tests/test_custom_operator.py
+++ b/tests/test_custom_operator.py
@@ -10,6 +10,7 @@ from typing import Dict
 
 import numpy
 
+import spox.opset.ai.onnx.v17 as op
 from spox import Var
 from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
 from spox._graph import arguments, results
@@ -66,7 +67,7 @@ def inverse(matrix: Var) -> Var:
 
 
 # Test the correct runtime behaviour with ORT
-def test_basic_build(op, onnx_helper):
+def test_basic_build(onnx_helper):
     (a,) = arguments(a=Tensor(numpy.float64, ("N", "N")))
     graph = results(b=inverse(a))
     onnx_helper.assert_close(
@@ -75,7 +76,7 @@ def test_basic_build(op, onnx_helper):
     )
 
 
-def test_node_overrides(op):
+def test_node_overrides():
     f = numpy.array([[1, 0], [1, 1]], dtype=numpy.float64)
     a = op.constant(value=f)
     b = inverse(a)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -42,8 +42,9 @@ def linear():
         outputs: Outputs
 
         def constructor(self, attrs: Dict[str, _Ref], inputs: Inputs) -> Outputs:
-            a = op.constant(value_float=attrs["slope"])
-            b = op.constant(value_float=attrs["shift"])
+            # FIXME: At some point, attribute references should be properly type-hinted.
+            a = op.constant(value_float=attrs["slope"])  # type: ignore
+            b = op.constant(value_float=attrs["shift"])  # type: ignore
             x = inputs.X
             return self.Outputs(op.add(op.mul(a, x), b))
 
@@ -79,7 +80,7 @@ def linear2(linear):
         outputs: Outputs
 
         def constructor(self, attrs: Dict[str, _Ref], inputs: Inputs) -> Outputs:
-            return self.Outputs(linear(inputs.X, attrs["slope1"], attrs["shift1"]))
+            return self.Outputs(linear(inputs.X, attrs["slope1"], attrs["shift1"]))  # type: ignore
 
     def linear_inner(x: Var, a: float, b: float) -> Var:
         return LinearFunction2(
@@ -116,10 +117,10 @@ def cubic(linear):
 
         def constructor(self, attrs: Dict[str, _Ref], inputs: Inputs) -> Outputs:
             x = inputs.X
-            a = op.mul(linear(x, attrs["a3"], attrs["a2"]), op.mul(x, x))
+            a = op.mul(linear(x, attrs["a3"], attrs["a2"]), op.mul(x, x))  # type: ignore
             b = op.add(
-                op.mul(x, op.constant(value_float=attrs["a1"])),
-                op.constant(value_float=attrs["a0"]),
+                op.mul(x, op.constant(value_float=attrs["a1"])),  # type: ignore
+                op.constant(value_float=attrs["a0"]),  # type: ignore
             )
             y = op.add(a, b)
             return self.Outputs(y)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -9,6 +9,7 @@ import onnx.shape_inference
 import onnxruntime
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._attributes import AttrFloat32, _Ref
 from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
 from spox._function import Function, to_function
@@ -19,7 +20,7 @@ from spox._var import Var
 
 
 @pytest.fixture
-def linear(op):
+def linear():
     class LinearFunction(Function):
         @dataclass
         class Attributes(BaseAttributes):
@@ -56,7 +57,7 @@ def linear(op):
 
 
 @pytest.fixture
-def linear2(op, linear):
+def linear2(linear):
     class LinearFunction2(Function):
         @dataclass
         class Attributes(BaseAttributes):
@@ -90,7 +91,7 @@ def linear2(op, linear):
 
 
 @pytest.fixture
-def cubic(op, linear):
+def cubic(linear):
     class CubicFunction(Function):
         @dataclass
         class Attributes(BaseAttributes):
@@ -138,13 +139,13 @@ def cubic(op, linear):
 
 
 @pytest.fixture
-def min_fun_graph(op, linear):
+def min_fun_graph(linear):
     (start,) = arguments(start=Tensor(numpy.float32, (None,)))
     return results(final=linear(start, 3, 2))
 
 
 @pytest.fixture
-def big_fun_graph(op, linear):
+def big_fun_graph(linear):
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
@@ -152,37 +153,37 @@ def big_fun_graph(op, linear):
 
 
 @pytest.fixture
-def double_fun_graph(op, linear):
+def double_fun_graph(linear):
     (start,) = arguments(start=Tensor(numpy.float32, (None,)))
     return results(final=linear(linear(start, 3, 2), 5, 3))
 
 
 @pytest.fixture
-def wrapped_linear_graph(op, linear2):
+def wrapped_linear_graph(linear2):
     (start,) = arguments(start=Tensor(numpy.float32, (None,)))
     return results(final=linear2(start, 3, 2))
 
 
 @pytest.fixture
-def cubic_graph(op, cubic):
+def cubic_graph(cubic):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
     return results(y=cubic(x, 5, 3, 2, 1))
 
 
 @pytest.fixture
-def cubic_rational_graph(op, cubic):
+def cubic_rational_graph(cubic):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
     return results(y=op.div(cubic(x, 5, 3, 2, 1), cubic(x, 3, 4, 2, 3)))
 
 
 @pytest.fixture
-def cubic_rational_graph_2x3(op, linear, cubic):
+def cubic_rational_graph_2x3(linear, cubic):
     (x,) = arguments(x=Tensor(numpy.float32, (None,)))
     return results(y=linear(op.div(cubic(x, 5, 3, 2, 1), cubic(x, 3, 4, 2, 3)), 2, 3))
 
 
 @pytest.fixture
-def isnan_graph(op):
+def isnan_graph():
     x, y, z = arguments(
         x=Tensor(numpy.float64, ()),
         y=Tensor(numpy.float64, ()),

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,13 +1,14 @@
 import numpy
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments, initializer, results
 from spox._internal_op import intro
 from spox._type_system import Tensor
 
 
 @pytest.fixture
-def min_graph(op):
+def min_graph():
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
@@ -15,13 +16,13 @@ def min_graph(op):
 
 
 @pytest.fixture
-def square_graph(op):
+def square_graph():
     (value,) = arguments(value=Tensor(numpy.float32, (None,)))
     return results(final=op.identity(op.mul(value, value)))
 
 
 @pytest.fixture
-def trivial_seq_graph(op):
+def trivial_seq_graph():
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
@@ -29,7 +30,7 @@ def trivial_seq_graph(op):
 
 
 @pytest.fixture
-def expanding_seq_graph(op):
+def expanding_seq_graph():
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
@@ -37,7 +38,7 @@ def expanding_seq_graph(op):
 
 
 @pytest.fixture
-def copy_graph(op):
+def copy_graph():
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float64, (None,))
     )
@@ -45,7 +46,7 @@ def copy_graph(op):
 
 
 @pytest.fixture
-def tri_graph(op):
+def tri_graph():
     first, second, third = arguments(
         first=Tensor(numpy.float32, (2, None)),
         second=Tensor(numpy.float32, (None,)),
@@ -57,7 +58,7 @@ def tri_graph(op):
 
 
 @pytest.fixture
-def initializer_graph(op):
+def initializer_graph():
     normal, defaulted = arguments(
         normal=Tensor(numpy.float32, (None,)),
         defaulted=numpy.array([3, 2, 1], dtype=numpy.float32),
@@ -103,7 +104,7 @@ def test_expanding_seq(onnx_helper, expanding_seq_graph):
     )
 
 
-def test_no_shape_throws(op):
+def test_no_shape_throws():
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32)
     )
@@ -112,7 +113,7 @@ def test_no_shape_throws(op):
         fun.to_onnx_model()
 
 
-def test_no_type_throws(op):
+def test_no_type_throws():
     with pytest.raises(TypeError):
         first, second = arguments(first=Tensor(numpy.float32, (None,)), second=None)
 

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -3,6 +3,7 @@ import onnx
 import onnx.parser
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments, results
 from spox._public import inline
 from spox._type_system import Tensor
@@ -92,7 +93,7 @@ agraph (double[N] a, double[N] b) => (double[N] c)
 
 
 @pytest.fixture
-def min_graph(op, lin_fun_proto):
+def min_graph(lin_fun_proto):
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
@@ -116,7 +117,7 @@ def test_minimal(onnx_helper, min_graph):
 
 
 @pytest.fixture
-def larger_graph(op, lin_fun_proto):
+def larger_graph(lin_fun_proto):
     first, second = arguments(
         first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
     )
@@ -136,7 +137,7 @@ def test_larger(onnx_helper, larger_graph):
 
 
 @pytest.fixture
-def add4_graph(op, add_proto):
+def add4_graph(add_proto):
     def add(x, y):
         return inline(add_proto)(A=x, B=y)["C"]
 
@@ -157,7 +158,7 @@ def test_repeated(onnx_helper, add4_graph):
 
 
 @pytest.fixture
-def inc3_graph(op, inc_proto):
+def inc3_graph(inc_proto):
     def inc(s):
         return inline(inc_proto)(X=s)["Y"]
 
@@ -172,7 +173,7 @@ def test_inc3_with_initializer(onnx_helper, inc3_graph):
 
 
 @pytest.fixture
-def inc3_graph_sparse_init(op, inc_proto_sparse_one):
+def inc3_graph_sparse_init(inc_proto_sparse_one):
     def inc(s):
         return inline(inc_proto_sparse_one)(X=s)["Y"]
 
@@ -186,7 +187,7 @@ def test_inc3_with_sparse_initializer(onnx_helper, inc3_graph_sparse_init):
     onnx_helper.assert_close(onnx_helper.run(inc3_graph_sparse_init, "y", x=x), x + 3)
 
 
-def test_inc3_value_prop(op, inc_proto):
+def test_inc3_value_prop(inc_proto):
     def inc(s):
         return inline(inc_proto)(X=s)["Y"]
 

--- a/tests/test_opsets.py
+++ b/tests/test_opsets.py
@@ -1,6 +1,6 @@
-from spox.opset.ai.onnx import v17 as op17
-from spox.opset.ai.onnx import v18 as op18
-from spox.opset.ai.onnx.ml import v3 as ml3
+import spox.opset.ai.onnx.ml.v3 as ml3
+import spox.opset.ai.onnx.v17 as op17
+import spox.opset.ai.onnx.v18 as op18
 
 
 def test_ai_onnx_v17():

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -1,10 +1,11 @@
 import numpy
 
+import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments
 from spox._type_system import Optional, Tensor
 
 
-def test_optional_type_objects(op):
+def test_optional_type_objects():
     (a,) = arguments(a=Tensor(numpy.int64, ()))
     assert op.optional(a).type == Optional(Tensor(numpy.int64, ()))
     assert op.optional(type=a.type).type == Optional(Tensor(numpy.int64, ()))

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -59,5 +59,5 @@ def test_multiple_outputs():
         a=Tensor(numpy.float32, ("N", "M", "K")), b=Tensor(numpy.int64, (1,))
     )
     values, indices = op.top_k(x, k)
-    assert values.type._subtype(Tensor(numpy.float32, ("N", "M", None)))
-    assert indices.type._subtype(Tensor(numpy.int64, ("N", "M", None)))
+    assert values.unwrap_type()._subtype(Tensor(numpy.float32, ("N", "M", None)))
+    assert indices.unwrap_type()._subtype(Tensor(numpy.int64, ("N", "M", None)))

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -1,29 +1,30 @@
 import numpy
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._exceptions import InferenceError
 from spox._graph import arguments
 from spox._type_system import Tensor
 
 
-def test_basic_inference(op):
+def test_basic_inference():
     a, b = arguments(a=Tensor(numpy.float32, ("N",)), b=Tensor(numpy.float32, (2, "N")))
     assert op.add(a, b).type == Tensor(numpy.float32, (2, "N"))
 
 
-def test_variadic_input_inference(op):
+def test_variadic_input_inference():
     typ = Tensor(numpy.float32, ("N",))
     a, b, c = arguments(a=typ, b=typ, c=typ)
     assert op.max([a, b, c]).type == typ
 
 
-def test_variadic_output_inference(op):
+def test_variadic_output_inference():
     (x,) = arguments(x=Tensor(numpy.float32, (3, "N")))
     x1, x2, x3 = op.split(x, op.const([1, 1, 1]), outputs_count=3)
     assert x1.type == x2.type == x3.type == Tensor(numpy.float32, (1, "N"))
 
 
-def test_optional_input_inference(op):
+def test_optional_input_inference():
     (x,) = arguments(x=Tensor(numpy.float32, ("N",)))
     assert op.clip(x, max=op.constant(value_float=1.0)).type == Tensor(
         numpy.float32, ("N",)
@@ -36,24 +37,24 @@ def test_optional_input_inference(op):
     ).type == Tensor(numpy.float32, ("N",))
 
 
-def test_function_body_inference(op):
+def test_function_body_inference():
     a, b = arguments(a=Tensor(numpy.float32, ("N",)), b=Tensor(numpy.float32, ("N",)))
     assert op.greater_or_equal(a, b).type == Tensor(numpy.bool_, ("N",))
 
 
-def test_inference_fails(op):
+def test_inference_fails():
     a, b = arguments(a=Tensor(numpy.float32, (2,)), b=Tensor(numpy.float32, (3,)))
     with pytest.raises(InferenceError):
         op.add(a, b)
 
 
-def test_inference_validation_fails(op):
+def test_inference_validation_fails():
     a, b = arguments(a=Tensor(numpy.float32, (2,)), b=Tensor(numpy.float64, (2,)))
     with pytest.raises(InferenceError):
         op.add(a, b)
 
 
-def test_multiple_outputs(op):
+def test_multiple_outputs():
     x, k = arguments(
         a=Tensor(numpy.float32, ("N", "M", "K")), b=Tensor(numpy.int64, (1,))
     )

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -1,11 +1,12 @@
 import numpy
 import pytest
 
+import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments, results
 from spox._type_system import Sequence, Tensor
 
 
-def test_subgraph(op, onnx_helper):
+def test_subgraph(onnx_helper):
     (e,) = arguments(e=Tensor(numpy.int64, ()))
     lp, sc = op.loop(
         v_initial=[op.constant(value_floats=[0.0])],  # Initial carry
@@ -28,7 +29,7 @@ def test_subgraph(op, onnx_helper):
     )
 
 
-def test_subgraph_copy_result(op, onnx_helper):
+def test_subgraph_copy_result(onnx_helper):
     b, x, y = arguments(
         b=Tensor(numpy.bool_, ()), x=Tensor(numpy.int64, ()), y=Tensor(numpy.int64, ())
     )
@@ -60,7 +61,7 @@ def test_subgraph_copy_result(op, onnx_helper):
     )
 
 
-def test_subgraph_non_copy_repeated_result(op, onnx_helper):
+def test_subgraph_non_copy_repeated_result(onnx_helper):
     b, x, y = arguments(
         b=Tensor(numpy.bool_, ()), x=Tensor(numpy.int64, ()), y=Tensor(numpy.int64, ())
     )
@@ -94,7 +95,7 @@ def test_subgraph_non_copy_repeated_result(op, onnx_helper):
     )
 
 
-def test_outer_scope_arguments(op, onnx_helper):
+def test_outer_scope_arguments(onnx_helper):
     b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
     (r,) = op.if_(
         b, else_branch=lambda: [op.add(x, x)], then_branch=lambda: [op.mul(x, x)]
@@ -120,7 +121,7 @@ def test_outer_scope_arguments(op, onnx_helper):
     )
 
 
-def test_outer_scope_arguments_nested(op, onnx_helper):
+def test_outer_scope_arguments_nested(onnx_helper):
     b, c, x, y = arguments(
         b=Tensor(numpy.bool_, ()),
         c=Tensor(numpy.bool_, ()),
@@ -170,7 +171,7 @@ def test_outer_scope_arguments_nested(op, onnx_helper):
     )
 
 
-def test_outer_scope_arguments_nested_used_in_both(op, onnx_helper):
+def test_outer_scope_arguments_nested_used_in_both(onnx_helper):
     b, c, x, y = arguments(
         b=Tensor(numpy.bool_, ()),
         c=Tensor(numpy.bool_, ()),
@@ -190,7 +191,7 @@ def test_outer_scope_arguments_nested_used_in_both(op, onnx_helper):
     graph.to_onnx_model(check_model=2)
 
 
-def test_subgraph_argument_used_only_in_subsubgraph(op, onnx_helper):
+def test_subgraph_argument_used_only_in_subsubgraph(onnx_helper):
     (r,) = op.loop(
         M=op.const([5]),
         v_initial=[],
@@ -207,7 +208,7 @@ def test_subgraph_argument_used_only_in_subsubgraph(op, onnx_helper):
     graph.to_onnx_model(check_model=2)
 
 
-def test_copied_outer_argument(op, onnx_helper):
+def test_copied_outer_argument(onnx_helper):
     b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
     (r,) = op.if_(b, else_branch=lambda: [x], then_branch=lambda: [x])
     graph = results(r=op.add(x, r))
@@ -222,7 +223,7 @@ def test_copied_outer_argument(op, onnx_helper):
     )
 
 
-def test_outer_scope_argument_used_only_inner(op, onnx_helper):
+def test_outer_scope_argument_used_only_inner(onnx_helper):
     b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
     two = op.const(numpy.float32(2.0))
     (r,) = op.if_(b, else_branch=lambda: [x], then_branch=lambda: [op.mul(two, x)])
@@ -247,7 +248,7 @@ def test_outer_scope_argument_used_only_inner(op, onnx_helper):
     )
 
 
-def test_subgraph_arguments_kept_separate(op, onnx_helper):
+def test_subgraph_arguments_kept_separate(onnx_helper):
     a, b = arguments(a=Tensor(numpy.int64, ()), b=Tensor(numpy.int64, ()))
 
     x, y = op.loop(
@@ -275,7 +276,7 @@ def test_subgraph_arguments_kept_separate(op, onnx_helper):
     )
 
 
-def test_scan_for_product(op, onnx_helper):
+def test_scan_for_product(onnx_helper):
     (x,) = arguments(x=Tensor(numpy.int32, ("N",)))
     one = op.const(numpy.array(1, dtype=numpy.int32))
     prod, _x = op.scan([one, x], body=lambda a, p: [op.mul(a, p), a], num_scan_inputs=1)
@@ -289,7 +290,7 @@ def test_scan_for_product(op, onnx_helper):
     )
 
 
-def test_sequence_map_for_zip_mul(op, onnx_helper):
+def test_sequence_map_for_zip_mul(onnx_helper):
     xs, ys = arguments(
         xs=Sequence(Tensor(numpy.int64)), ys=Sequence(Tensor(numpy.int64))
     )
@@ -305,7 +306,7 @@ def test_sequence_map_for_zip_mul(op, onnx_helper):
     )
 
 
-def test_graph_inherits_subgraph_opset_req(op, onnx_helper):
+def test_graph_inherits_subgraph_opset_req(onnx_helper):
     import spox.opset.ai.onnx.ml.v3 as ml
 
     xs, ys = arguments(
@@ -331,12 +332,12 @@ def test_graph_inherits_subgraph_opset_req(op, onnx_helper):
     )
 
 
-def test_subgraph_not_callback_raises(op):
+def test_subgraph_not_callback_raises():
     with pytest.raises(TypeError):
         op.if_(op.const(True), then_branch=[op.const(0)], else_branch=[op.const(1)])
 
 
-def test_subgraph_not_iterable_raises(op):
+def test_subgraph_not_iterable_raises():
     with pytest.raises(TypeError):
         op.if_(
             op.const(True),
@@ -345,7 +346,7 @@ def test_subgraph_not_iterable_raises(op):
         )
 
 
-def test_subgraph_not_var_iterable_raises(op):
+def test_subgraph_not_var_iterable_raises():
     with pytest.raises(TypeError):
         op.if_(
             op.const(True), then_branch=lambda: [0], else_branch=lambda: [op.const(1)]

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -334,20 +334,26 @@ def test_graph_inherits_subgraph_opset_req(onnx_helper):
 
 def test_subgraph_not_callback_raises():
     with pytest.raises(TypeError):
-        op.if_(op.const(True), then_branch=[op.const(0)], else_branch=[op.const(1)])
+        op.if_(
+            op.const(True),
+            then_branch=[op.const(0)],  # type: ignore
+            else_branch=[op.const(1)],  # type: ignore
+        )
 
 
 def test_subgraph_not_iterable_raises():
     with pytest.raises(TypeError):
         op.if_(
             op.const(True),
-            then_branch=lambda: op.const(0),
-            else_branch=lambda: op.const(1),
+            then_branch=lambda: op.const(0),  # type: ignore
+            else_branch=lambda: op.const(1),  # type: ignore
         )
 
 
 def test_subgraph_not_var_iterable_raises():
     with pytest.raises(TypeError):
         op.if_(
-            op.const(True), then_branch=lambda: [0], else_branch=lambda: [op.const(1)]
+            op.const(True),
+            then_branch=lambda: [0],  # type: ignore
+            else_branch=lambda: [op.const(1)],
         )

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -360,7 +360,7 @@ def test_subgraph_not_var_iterable_raises():
         )
 
 
-def test_subgraph_basic_initializer(op, onnx_helper):
+def test_subgraph_basic_initializer(onnx_helper):
     (e,) = arguments(e=Tensor(bool, ()))
     (f,) = op.if_(
         e, then_branch=lambda: [initializer(0)], else_branch=lambda: [op.const(1)]

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -1,6 +1,7 @@
 import numpy
 
 import spox.opset.ai.onnx.ml.v3 as ml
+import spox.opset.ai.onnx.v17 as op
 from spox import Var, _type_system
 from spox._graph import arguments, results
 from spox._shape import Shape
@@ -52,27 +53,27 @@ def assert_equal_value(var: Var, expected: ORTValue):
         raise NotImplementedError(f"Datatype {var.type}")
 
 
-def test_sanity_no_prop(op):
+def test_sanity_no_prop():
     (x,) = arguments(x=_type_system.Tensor(numpy.int64, ()))
     op.add(x, x)
 
 
-def test_sanity_const(op):
+def test_sanity_const():
     assert_equal_value(op.const(2), numpy.int64(2))
 
 
-def test_add(op):
+def test_add():
     assert_equal_value(op.add(op.const(2), op.const(2)), numpy.int64(4))
 
 
-def test_div(op):
+def test_div():
     assert_equal_value(
         op.div(op.const(numpy.float32(5.0)), op.const(numpy.float32(2.0))),
         numpy.float32(2.5),
     )
 
 
-def test_identity(op):
+def test_identity():
     for x in [
         5,
         [1, 2, 3],
@@ -82,21 +83,21 @@ def test_identity(op):
         assert_equal_value(op.const(x), x)
 
 
-def test_reshape(op):
+def test_reshape():
     assert_equal_value(
         op.reshape(op.const([1, 2, 3, 4]), op.const([2, 2])), [[1, 2], [3, 4]]
     )
 
 
-def test_optional(op):
+def test_optional():
     assert_equal_value(op.optional(op.const(numpy.float32(2.0))), numpy.float32(2.0))
 
 
-def test_empty_optional(op):
+def test_empty_optional():
     assert_equal_value(op.optional(type=_type_system.Tensor(numpy.float32, ())), None)
 
 
-def test_empty_optional_has_no_element(op):
+def test_empty_optional_has_no_element():
     assert_equal_value(
         op.optional_has_element(
             op.optional(type=_type_system.Tensor(numpy.float32, ()))
@@ -105,18 +106,18 @@ def test_empty_optional_has_no_element(op):
     )
 
 
-def test_sequence_empty(op):
+def test_sequence_empty():
     assert_equal_value(op.sequence_empty(dtype=numpy.float32), [])
 
 
-def test_sequence_append(op):
+def test_sequence_append():
     emp = op.sequence_empty(dtype=numpy.int64)
     assert_equal_value(
         op.sequence_insert(op.sequence_insert(emp, op.const(2)), op.const(1)), [2, 1]
     )
 
 
-def test_with_reconstruct(op):
+def test_with_reconstruct():
     a, b = arguments(
         a=_type_system.Tensor(numpy.int64, ()),
         b=_type_system.Tensor(numpy.int64, ()),
@@ -130,7 +131,7 @@ def test_with_reconstruct(op):
     )
 
 
-def test_bad_reshape_fails(caplog, op):
+def test_bad_reshape_fails(caplog):
     caplog.set_level("DEBUG")
     _ = op.reshape(op.const([1, 2]), op.const([2]))  # sanity
     assert not caplog.records
@@ -138,7 +139,7 @@ def test_bad_reshape_fails(caplog, op):
     assert any(record.levelname == "DEBUG" for record in caplog.records)
 
 
-def test_give_up_silently(op):
+def test_give_up_silently():
     # The LabelEncoder currently has no reference implementation.
     ml.label_encoder(
         op.const(numpy.array(["foo"])),
@@ -148,5 +149,5 @@ def test_give_up_silently(op):
     )
 
 
-def test_non_ascii_characters_in_string_tensor(op):
+def test_non_ascii_characters_in_string_tensor():
     op.cast(op.constant(value_string="FööBär"), to=str)

--- a/tests/type_inference/test_compress.py
+++ b/tests/type_inference/test_compress.py
@@ -13,7 +13,7 @@ def test_compress_inference():
     assert op.compress(x, y, axis=1).unwrap_tensor() == Tensor(float, ("N", None))
 
 
-def test_compress_inference_checks_bool_cond(op):
+def test_compress_inference_checks_bool_cond():
     (x,) = arguments(x=Tensor(float, ("N", "M")))
     with pytest.raises(InferenceError):
         op.compress(x, op.const(123)).unwrap_tensor()


### PR DESCRIPTION
The `op` fixture is an old antique that has been in the codebase for a long time. It doesn't really make sense to test on multiple opsets, as if the operators don't remain the same, they may have breaking changes. Instead, they should be tested separately - for Spox specifically we only care about checking if we can replicate specific behaviour in the framework, hence we only need to think about fixed versions.
This PR removes the opset fixture. It depends on #57 which should be merged first.