### PR TITLE
Patch type inference of carry-values in `Loop`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Change log
 
 - ``spox.inline`` now correctly renames unused model inputs when building. This could previously cause invalid models to be built.
 - Array attributes are now copied when they are passed to an operator. This avoids accidentally mutating them after the operator is constructed.
+- The ``Loop`` operator now has patched type inference, so that the loop-carries in its results preserve shapes if the subgraph had them inferred.
 
 0.6.1 (2023-03-07)
 ------------------

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -1780,6 +1780,20 @@ class _Loop(StandardNode):
     class Outputs(BaseOutputs):
         v_final_and_scan_outputs: Sequence[Var]
 
+    def infer_output_types(self) -> Dict[str, Type]:
+        output_types = super().infer_output_types()
+
+        body = self.attrs.body.value
+        n = len(body.requested_arguments) - 2
+
+        carried_names = list(self.outputs.get_vars())[:n]
+        carried_types = [v.type for v in list(body.requested_results.values())[1:][:n]]
+
+        for name, typ in zip(carried_names, carried_types):
+            output_types[name] = typ
+
+        return output_types
+
     op_type = OpType("Loop", "", 16)
 
     attrs: Attributes

--- a/tests/type_inference/test_loop.py
+++ b/tests/type_inference/test_loop.py
@@ -9,4 +9,4 @@ def test_loop_inference():
     )
     assert x.type == Tensor(float, (None,))
     assert y.type == Tensor(int, ("N", 2))
-    assert zs.type == Tensor(int, (None,))
+    assert zs.type == Tensor(int, (None, 1))

--- a/tests/type_inference/test_loop.py
+++ b/tests/type_inference/test_loop.py
@@ -1,0 +1,12 @@
+import spox.opset.ai.onnx.v17 as op
+from spox import Tensor, argument
+
+
+def test_loop_inference():
+    x, y, zs = op.loop(
+        v_initial=[argument(Tensor(float, (None,))), argument(Tensor(int, ("N", 2)))],
+        body=lambda i, c, a, b: [op.const(True), a, op.add(i, b), i],
+    )
+    assert x.type == Tensor(float, (None,))
+    assert y.type == Tensor(int, ("N", 2))
+    assert zs.type == Tensor(int, (None,))

--- a/tools/generate_opset.py
+++ b/tools/generate_opset.py
@@ -630,7 +630,7 @@ if __name__ == "__main__":
         "ai.onnx",
         17,
         extras=["const"],
-        type_inference={"Compress": "compress11"},
+        type_inference={"Compress": "compress11", "Loop": "loop16-fix"},
         value_propagation={"Constant": "constant13"},
         out_variadic_solutions=V16_OUT_VARIADIC_SOLUTIONS,
         subgraphs_solutions=V16_SUBGRAPH_SOLUTIONS,

--- a/tools/templates/type_inference/loop16-fix.jinja2
+++ b/tools/templates/type_inference/loop16-fix.jinja2
@@ -1,0 +1,12 @@
+output_types = super().infer_output_types()
+
+body = self.attrs.body.value
+n = len(body.requested_arguments) - 2
+
+carried_names = list(self.outputs.get_vars())[:n]
+carried_types = [v.type for v in list(body.requested_results.values())[1:][:n]]
+
+for name, typ in zip(carried_names, carried_types):
+    output_types[name] = typ
+
+return output_types


### PR DESCRIPTION
Though `Loop` has almost-complete type inference, seemingly due to a bug loop-carries don't have their shapes inferred. This is even though the subgraph states (or at least may state) their types explicitly. This is a patch that bases on the builtin inference and then adds the types from loop carries. 
A respective test (though loops are also tested in `full/`) and changelog notice is added.