### PR TITLE
Generate API docs for `ai.onnx@18`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Spox is a Python framework for constructing `ONNX <https://github.com/onnx/onnx/
 
    API Reference <api/modules>
    Operator constructors for the ai.onnx domain version 17 <api/spox.opset.ai.onnx.v17>
+   Operator constructors for the ai.onnx domain version 18 <api/spox.opset.ai.onnx.v18>
    Operator constructors for the ai.onnx.ml domain version 3 <api/spox.opset.ai.onnx.ml.v3>
 
 

--- a/docs/manual/unstable.rst
+++ b/docs/manual/unstable.rst
@@ -90,6 +90,7 @@ Initializers
 Initializers are an ONNX mechanism for expressing constant tensor values in the model. Spox provides a function to create them:
 
 ..  code:: python
+
     def initializer(value: ArrayLike, dtype: DTypeLike = None) -> Var:
         ...
 


### PR DESCRIPTION
They are currently missing online.