### PR TITLE
Fix issues with non-trivial scope resolution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@
 Change log
 ==========
 
+0.7.1 (2023-04-xx)
+------------------
+
+- Fix an issue with resolving scopes during the build process. They manifested with a ``KeyError`` in accessing variables in scope on graphs in complex dependencies between subgraphs.
+
+
 0.7.0 (2023-04-04)
 ------------------
 

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -305,12 +305,13 @@ class Builder:
           graph that we are in (as this is an indirect result to this graph).
           In this case we update the scope to the LCA of this graph's scope and the existing scope.
         - This cannot break the input-scope (1st) constraint (as we only expose more values to scopes),
-          and the 2nd constraint is not moved.
-        - We may recursively descend into subgraphs found by traversing this graph. This will serve to update the scope
-          tree and satisfy that subgraph's constraints.
+          and the 2nd constraint is not affected.
 
         Pessimistically an LCA constraint update may be O(s), and all n nodes may be visited in all s scopes.
-        However, a node may be pushed up in the scope tree at most O(s) time, so the complexity is amortised to O(ns).
+        However, a node may be pushed up in the scope tree at most O(s) times, so the complexity is amortised to O(ns).
+
+        It is expected that subgraphs reachable from the source of ``graph`` have already been resolved.
+        This is why this method is called for all graphs with topological ordering.
         """
 
         def satisfy_constraints(node):

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -153,10 +153,16 @@ class Builder:
             Time and space complexity in the length of the path between a, b in the tree.
             """
             vis = set()
+            graphs = list(set(self.subgraph_of) | set(self.scope_of.values()))
+            p = {g: graphs.index(g) for g in graphs}
+            _a, _b = a, b
             while a not in vis:
                 vis.add(a)
                 a = self.parent(a)
                 a, b = b, a
+            print(
+                f"lca({p[_a]}, {p[_b]}) = {p[a]}  at {[(p[g], p[self.parent(g)]) for g in self.subgraph_of]}"
+            )
             return a
 
     # Graphs needed in the build

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -308,6 +308,8 @@ class Builder:
                 if sub not in self.scope_tree.subgraph_of:
                     self.scope_tree.subgraph_of[sub] = node
                     self.update_scope_tree(sub)
+                if self.scope_tree.subgraph_of[sub] != node:
+                    raise BuildError("Two nodes reused the same subgraph.")
 
         # Visit from the source (result) of this graph. Traverse only input edges for the first constraint.
         iterative_dfs(

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -152,17 +152,12 @@ class Builder:
 
             Time and space complexity in the length of the path between a, b in the tree.
             """
-            vis = set()
-            graphs = list(set(self.subgraph_of) | set(self.scope_of.values()))
-            p = {g: graphs.index(g) for g in graphs}
-            _a, _b = a, b
-            while a not in vis:
-                vis.add(a)
+            vis_a, vis_b = {a}, {b}
+            while a not in vis_b:
+                vis_a.add(a)
                 a = self.parent(a)
                 a, b = b, a
-            print(
-                f"lca({p[_a]}, {p[_b]}) = {p[a]}  at {[(p[g], p[self.parent(g)]) for g in self.subgraph_of]}"
-            )
+                vis_a, vis_b = vis_b, vis_a
             return a
 
     # Graphs needed in the build

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -146,23 +146,18 @@ class Builder:
             """
             A simple LCA algorithm without preprocessing that only accesses the parents.
 
-            The algorithm is simple - we keep going up one step with both nodes
-            Whenever we hit a node that was already visited, it must be the lowest common ancestor
+            The algorithm is simple - we keep going up one step alternating between the nodes.
+            Whenever we hit a node that was already visited, it must be the lowest common ancestor.
             - as it is definitely a common ancestor, and it required the least steps up.
 
             Time and space complexity in the length of the path between a, b in the tree.
             """
-            if a is b:
-                return a
             vis = set()
-            while True:
-                if a in vis:
-                    return a
-                if b in vis:
-                    return b
+            while a not in vis:
                 vis.add(a)
-                vis.add(b)
-                a, b = self.parent(a), self.parent(b)
+                a = self.parent(a)
+                a, b = b, a
+            return a
 
     # Graphs needed in the build
     main: "Graph"

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -311,7 +311,8 @@ class Builder:
         However, a node may be pushed up in the scope tree at most O(s) times, so the complexity is amortised to O(ns).
 
         It is expected that subgraphs reachable from the source of ``graph`` have already been resolved.
-        This is why this method is called for all graphs with topological ordering.
+        This method is called for all graphs in topological ordering, which ensures the scope tree
+        is completed 'bottom-up'.
         """
 
         def satisfy_constraints(node):

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -8017,6 +8017,9 @@ def identity(
     ).outputs.output
 
 
+_if_cnt = 0
+
+
 def if_(
     cond: Var,
     *,
@@ -8069,8 +8072,10 @@ def if_(
      - B: `tensor(bool)`
      - V: `optional(seq(tensor(bfloat16)))`, `optional(seq(tensor(bool)))`, `optional(seq(tensor(complex128)))`, `optional(seq(tensor(complex64)))`, `optional(seq(tensor(double)))`, `optional(seq(tensor(float)))`, `optional(seq(tensor(float16)))`, `optional(seq(tensor(int16)))`, `optional(seq(tensor(int32)))`, `optional(seq(tensor(int64)))`, `optional(seq(tensor(int8)))`, `optional(seq(tensor(string)))`, `optional(seq(tensor(uint16)))`, `optional(seq(tensor(uint32)))`, `optional(seq(tensor(uint64)))`, `optional(seq(tensor(uint8)))`, `optional(tensor(bfloat16))`, `optional(tensor(bool))`, `optional(tensor(complex128))`, `optional(tensor(complex64))`, `optional(tensor(double))`, `optional(tensor(float))`, `optional(tensor(float16))`, `optional(tensor(int16))`, `optional(tensor(int32))`, `optional(tensor(int64))`, `optional(tensor(int8))`, `optional(tensor(string))`, `optional(tensor(uint16))`, `optional(tensor(uint32))`, `optional(tensor(uint64))`, `optional(tensor(uint8))`, `seq(tensor(bfloat16))`, `seq(tensor(bool))`, `seq(tensor(complex128))`, `seq(tensor(complex64))`, `seq(tensor(double))`, `seq(tensor(float))`, `seq(tensor(float16))`, `seq(tensor(int16))`, `seq(tensor(int32))`, `seq(tensor(int64))`, `seq(tensor(int8))`, `seq(tensor(string))`, `seq(tensor(uint16))`, `seq(tensor(uint32))`, `seq(tensor(uint64))`, `seq(tensor(uint8))`, `tensor(bfloat16)`, `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
-    _else_branch_subgraph: Graph = subgraph((), else_branch)
-    _then_branch_subgraph: Graph = subgraph((), then_branch)
+    global _if_cnt
+    _if_cnt += 1
+    _else_branch_subgraph: Graph = subgraph((), else_branch).with_name(f"ELSE{_if_cnt}")
+    _then_branch_subgraph: Graph = subgraph((), then_branch).with_name(f"THEN{_if_cnt}")
     return _If(
         _If.Attributes(
             else_branch=AttrGraph(_else_branch_subgraph),

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -8017,9 +8017,6 @@ def identity(
     ).outputs.output
 
 
-_if_cnt = 0
-
-
 def if_(
     cond: Var,
     *,
@@ -8072,10 +8069,8 @@ def if_(
      - B: `tensor(bool)`
      - V: `optional(seq(tensor(bfloat16)))`, `optional(seq(tensor(bool)))`, `optional(seq(tensor(complex128)))`, `optional(seq(tensor(complex64)))`, `optional(seq(tensor(double)))`, `optional(seq(tensor(float)))`, `optional(seq(tensor(float16)))`, `optional(seq(tensor(int16)))`, `optional(seq(tensor(int32)))`, `optional(seq(tensor(int64)))`, `optional(seq(tensor(int8)))`, `optional(seq(tensor(string)))`, `optional(seq(tensor(uint16)))`, `optional(seq(tensor(uint32)))`, `optional(seq(tensor(uint64)))`, `optional(seq(tensor(uint8)))`, `optional(tensor(bfloat16))`, `optional(tensor(bool))`, `optional(tensor(complex128))`, `optional(tensor(complex64))`, `optional(tensor(double))`, `optional(tensor(float))`, `optional(tensor(float16))`, `optional(tensor(int16))`, `optional(tensor(int32))`, `optional(tensor(int64))`, `optional(tensor(int8))`, `optional(tensor(string))`, `optional(tensor(uint16))`, `optional(tensor(uint32))`, `optional(tensor(uint64))`, `optional(tensor(uint8))`, `seq(tensor(bfloat16))`, `seq(tensor(bool))`, `seq(tensor(complex128))`, `seq(tensor(complex64))`, `seq(tensor(double))`, `seq(tensor(float))`, `seq(tensor(float16))`, `seq(tensor(int16))`, `seq(tensor(int32))`, `seq(tensor(int64))`, `seq(tensor(int8))`, `seq(tensor(string))`, `seq(tensor(uint16))`, `seq(tensor(uint32))`, `seq(tensor(uint64))`, `seq(tensor(uint8))`, `tensor(bfloat16)`, `tensor(bool)`, `tensor(complex128)`, `tensor(complex64)`, `tensor(double)`, `tensor(float)`, `tensor(float16)`, `tensor(int16)`, `tensor(int32)`, `tensor(int64)`, `tensor(int8)`, `tensor(string)`, `tensor(uint16)`, `tensor(uint32)`, `tensor(uint64)`, `tensor(uint8)`
     """
-    global _if_cnt
-    _if_cnt += 1
-    _else_branch_subgraph: Graph = subgraph((), else_branch).with_name(f"ELSE{_if_cnt}")
-    _then_branch_subgraph: Graph = subgraph((), then_branch).with_name(f"THEN{_if_cnt}")
+    _else_branch_subgraph: Graph = subgraph((), else_branch)
+    _then_branch_subgraph: Graph = subgraph((), then_branch)
     return _If(
         _If.Attributes(
             else_branch=AttrGraph(_else_branch_subgraph),

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -354,7 +354,7 @@ def test_subgraph_result_depends_on_result(onnx_helper):
 @pytest.mark.parametrize("f2", [0, 1, 2])
 @pytest.mark.parametrize("f3", [0, 1, 2])
 def test_binary_scope_trees_on_subgraph_argument(onnx_helper, f1, f2, f3):
-    def subgraph_id(arg: Var, fork) -> Var:
+    def id(arg: Var, fork) -> Var:
         (ret,) = (
             op.if_(
                 op.const(True),
@@ -370,7 +370,7 @@ def test_binary_scope_trees_on_subgraph_argument(onnx_helper, f1, f2, f3):
         v_initial=[op.const(0)],
         body=lambda _i, _c, a: (
             op.const(False),
-            subgraph_id(subgraph_id(subgraph_id(a, fork=f3), fork=f2), fork=f1),
+            id(id(id(a, fork=f3), fork=f2), fork=f1),
         ),
     )
 

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -352,7 +352,7 @@ def test_subgraph_result_depends_on_result(onnx_helper):
 
 @pytest.mark.parametrize("f1", [0, 1, 2])
 @pytest.mark.parametrize("f2", [0, 1, 2])
-@pytest.mark.parametrize("f3", [0])
+@pytest.mark.parametrize("f3", [0, 1, 2])
 def test_binary_scope_trees_on_subgraph_argument(onnx_helper, f1, f2, f3):
     def subgraph_id(arg: Var, fork) -> Var:
         (ret,) = (


### PR DESCRIPTION
## Context 

One of the stages of build is resolving where nodes should be put in subgraphs, which is called scope resolution. This creates a scope tree, which describes how scopes are related to each other (a tree is appropriate since with lexical scoping each scope can access values in its ancestors). The algorithm here finds the least enclosing scopes, which attempt to place nodes in the deepest scope possible without invalidating scopes.

## Description

This PR fixes some bugs in scope resolution.

- The implementation of LCA for the scope tree was wrong, which resulted in bugs when the paths to the LCA were not balanced or too close to the root. It has to be implemented in a slightly non-standard way as the tree that is dealt with is dynamic, but it should be correct now.
- The scopes were resolved in an order that was usually topological, but not on more tricky cases. Now it is strictly topological. This ensures nodes are properly initially marked as 'necessarily in this scope' (on that note, I rechecked that LCA seems necessary to satisfy these constraints properly).

There are also some new parameterised tests and a tricky case that I added to stress-test on different kinds of scope trees. 

## Notes

The bug surfaced when implementing a program with complex control flow patterns. It was quite difficult to debug, since:

- It only surfaced as a specific value (an Argument, which was coincidental) not being in scope at the last stage (compilation)
- The traceback is rather inadequate in the situation the build algorithm fails
- The code was quite complex at that point and it was difficult to isolate where the problem even was

The tools useful for fixing this were:

- Minimising the example to only contain the offending loop call
- Introspecting the tracebacks of where specific nodes got constructed (already possible with `Node._traceback`)
- Visualising the graph of operator and subgraph dependencies (under `networkx`)
- Manually naming all the subgraphs in the graph so that looking at relations between them is more useful

Maybe methods for achieving these should be integrated into the codebase to make this sort of problem easier to fix in the future, though the assumption is over time we will encounter them less and less. This has been the first time there were bugs in building - though I fixed two more extra bugs on the way so maybe they're just hard to discover naturally and should be tested more robustly.