### PR TITLE
Add context managers for global flags

### DIFF
--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -13,13 +13,33 @@ from spox._type_system import Tensor
 from spox._var import Var
 
 TypeWarningLevel = spox._node.TypeWarningLevel
-set_type_warning_level = spox._node.set_type_warning_level
+
+
+def set_type_warning_level(level: TypeWarningLevel) -> None:
+    spox._node._TYPE_WARNING_LEVEL = level
+
+
+@contextmanager
+def type_warning_level(level: TypeWarningLevel):
+    prev_level = spox._node._TYPE_WARNING_LEVEL
+    set_type_warning_level(level)
+    yield
+    set_type_warning_level(prev_level)
+
 
 ValuePropBackend = spox._value_prop.ValuePropBackend
 
 
 def set_value_prop_backend(backend: ValuePropBackend) -> None:
     spox._value_prop._VALUE_PROP_BACKEND = backend
+
+
+@contextmanager
+def value_prop_backend(backend: ValuePropBackend):
+    prev_backend = spox._value_prop._VALUE_PROP_BACKEND
+    set_value_prop_backend(backend)
+    yield
+    set_value_prop_backend(prev_backend)
 
 
 def initializer(value: npt.ArrayLike, dtype: npt.DTypeLike = None) -> Var:
@@ -189,11 +209,13 @@ __all__ = [
     # Type warning levels
     "TypeWarningLevel",
     "set_type_warning_level",
+    "type_warning_level",
     # Initializer-backed constants
     "initializer",
     # Value propagation backend
     "ValuePropBackend",
     "set_value_prop_backend",
+    "value_prop_backend",
     # Operator overloading on Var
     "operator_overloading",
 ]

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -39,11 +39,6 @@ class TypeWarningLevel(enum.IntEnum):
 _TYPE_WARNING_LEVEL: TypeWarningLevel = TypeWarningLevel.INITIAL
 
 
-def set_type_warning_level(level: TypeWarningLevel):
-    global _TYPE_WARNING_LEVEL
-    _TYPE_WARNING_LEVEL = level
-
-
 @dataclass(frozen=True)
 class OpType:
     """Stores information on an ONNX operator, like its identifier and domain."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,9 @@ import pytest
 
 from spox import _value_prop
 from spox._debug import show_construction_tracebacks
+from spox._future import set_type_warning_level
 from spox._graph import Graph
-from spox._node import TypeWarningLevel, set_type_warning_level
+from spox._node import TypeWarningLevel
 
 set_type_warning_level(TypeWarningLevel.CRITICAL)
 _value_prop.VALUE_PROP_STRICT_CHECK = True


### PR DESCRIPTION
`spox._future` currently has `set_type_warning_level` and `set_value_prop_backend` to be used in edge cases where the defaults don't work. This PR adds context manager versions for these, so that their effects can be better managed.