### PR TITLE
Build graphs with an explicit IR version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@
 Change log
 ==========
 
+
+0.7.1 (2023-05-09)
+------------------
+
+**New feature**
+
+- Spox now explicitly sets a model's IR version (currently to version 8) rather than defaulting to the latest IR version supported by the installed onnx package. Increasing the IR version is not considered a breaking change going forward. The IR version will be increase once the ecosystem has adopted it more broadly.
+
+
 0.7.0 (2023-04-04)
 ------------------
 

--- a/src/spox/_graph.py
+++ b/src/spox/_graph.py
@@ -349,11 +349,12 @@ class Graph:
 
     def to_onnx_model(
         self,
+        *,
         producer_name: str = "spox",
         model_doc_string: str = "",
         infer_shapes: bool = False,
         check_model: Union[Literal[0], Literal[1], Literal[2]] = 1,
-        *,
+        ir_version=8,
         concrete: bool = True,
     ) -> onnx.ModelProto:
         """
@@ -413,6 +414,7 @@ class Graph:
                 onnx.helper.make_operatorsetid(domain, version)
                 for domain, version in opsets.items()
             ],
+            ir_version=ir_version,
         )
 
         if infer_shapes:


### PR DESCRIPTION
The latest release of `onnx` has introduced a new IR version (9). The function `onnx.helper.make_model` implicitly defaults to the latest function. However, onnxruntime is not yet able to consume models with the latest IR version causing an error. Until the ecosystem had a reasonable amount of time to adopt the new IR version we should not produce models with it.

Setting the IR version like this is a safe way according to an upstream discussion: https://github.com/onnx/onnx/discussions/5203#discussioncomment-5841152

# Checklist

- [x] Added a `CHANGELOG.rst` entry
