### PR TITLE
Raise an error when a subgraph local is leaked to an outer scope

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Change log
 ==========
 
+0.8.1 (2023-05-xx)
+------------------
+
+**Bug fixes**
+
+- An explicit error is now raised when local subgraph arguments where leaked to an outer scope. This may happen when the subgraph callback causes unintuitive side effects, which would produce a confusing error message.
+
 0.8.0 (2023-05-11)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Change log
 
 **Bug fixes**
 
-- An explicit error is now raised when local subgraph arguments where leaked to an outer scope. This may happen when the subgraph callback causes unintuitive side effects, which would produce a confusing error message.
+- An explicit error is now raised when local subgraph arguments are leaked to an outer scope. This may happen when the subgraph callback uses side effects saving local variables, which would produce later a confusing error message.
 
 0.8.0 (2023-05-11)
 ------------------

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -303,8 +303,8 @@ class Builder:
         leaked = claimed_arguments & used_arguments
         if leaked:
             raise BuildError(
-                f"Some subgraph-local arguments were leaked to an outer scope. "
-                f"Hint: avoid side effects in your subgraph callbacks."
+                "Some subgraph-local arguments were leaked to an outer scope. "
+                "Hint: avoid side effects in your subgraph callbacks."
             )
         claimed_arguments |= set(self.arguments_of[graph])
 


### PR DESCRIPTION
Though this is quite minor, using side effects in subgraph callbacks is not safe if it causes the 'local' subgraph arguments (as passed to the callback by the operator) to be leaked to an outer scope graph. This obviously can't possibly build (we'd have to move the argument to the outer scope, but this isn't possible). 

I didn't really encounter this issue in the wild except figuring out it is possible in theory. I thought it was worth fixing as it's better to raise in Spox than in ONNX (at which point debugging what happened may be really difficult to someone down the line). 

Now build does an obvious check against this to produce a more helpful error message (a `BuildError` instead of a much delayed ONNX-side `ValidationError`).

- [x] Added a `CHANGELOG.rst` entry
