### PR TITLE
Implement a custom graph renaming routine for inline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.9.0 (2023-06-xx)
+------------------
+
+**Other changes**
+
+- Inlining now no longer adds redundant ``Identity`` nodes and supports subgraphs, thanks to reimplementing the ONNX renaming routine.
+
+
 0.8.1 (2023-05-xx)
 ------------------
 

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -35,7 +35,15 @@ def rename_in_graph(
         if nd.name and rename_node is not None:
             nd.name = rename_node(nd.name)
         if rename_op is not None:
-            nd.domain, nd.op_type = rename_op(nd.domain, nd.op_type)
+            # This is a bit elaborate, but we do it this way as
+            # an unset domain field is different from an empty one.
+            if nd.HasField("domain"):
+                nd.domain, nd.op_type = rename_op(nd.domain, nd.op_type)
+            else:
+                # An empty domain is the default domain (ai.onnx)
+                domain, nd.op_type = rename_op("", nd.op_type)
+                if domain:  # Only set the domain explicitly if it's changing
+                    nd.domain = domain
         for seq in (nd.input, nd.output):
             for i, name in enumerate(seq):
                 seq[i] = rename(name)

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -50,6 +50,18 @@ def rename_in_graph(
                         rename_op=rename_op,
                     )
                 )
+            elif isinstance(attr, list) and all(
+                isinstance(g, onnx.GraphProto) for g in attr
+            ):
+                for i in range(len(attr)):
+                    attr_proto.graphs[i].CopyFrom(
+                        rename_in_graph(
+                            attr[i],
+                            rename,
+                            rename_node=rename_node,
+                            rename_op=rename_op,
+                        )
+                    )
 
     for p in itertools.chain(graph.output, graph.value_info):
         p.name = rename(p.name)

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -20,7 +20,7 @@ def rename_in_graph(
     rename: Callable[[str], str],
     *,
     rename_node: Optional[Callable[[str], str]] = None,
-    rename_op_type: Optional[Callable[[str], str]] = None,
+    rename_op: Optional[Callable[[str, str], Tuple[str, str]]] = None,
 ) -> onnx.GraphProto:
     graph = onnx.GraphProto()
     graph.CopyFrom(graph_)
@@ -34,8 +34,8 @@ def rename_in_graph(
     for nd in graph.node:
         if nd.name and rename_node is not None:
             nd.name = rename_node(nd.name)
-        if nd.op_type and rename_op_type is not None:
-            nd.op_type = rename_op_type(nd.op_type)
+        if rename_op is not None:
+            nd.domain, nd.op_type = rename_op(nd.domain, nd.op_type)
         for seq in (nd.input, nd.output):
             for i, name in enumerate(seq):
                 seq[i] = rename(name)
@@ -47,7 +47,7 @@ def rename_in_graph(
                         attr,
                         rename,
                         rename_node=rename_node,
-                        rename_op_type=rename_op_type,
+                        rename_op=rename_op,
                     )
                 )
 

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -218,13 +218,11 @@ def inline(model: onnx.ModelProto) -> _InlineCall:
     _signature_msg = f"signature {in_names}{_defaults_msg} -> {out_names}"
 
     model = _copy_model(model)
-    # FIXME: Renaming does not work on subgraphs as of ONNX 1.13/1.14.
     for node in model.graph.node:
         for attr in node.attribute:
-            if attr.HasField("g") or attr.graphs:
+            if attr.graphs:
                 raise ValueError(
-                    "Inlining models with subgraphs is not supported due to "
-                    "lack of upstream support for renaming values in subgraphs."
+                    "Inlining models with variadic subgraph attributes is not supported."
                 )
     # FIXME: Support for functions is a bit involved, as it interacts with build.
     if model.functions:

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -218,12 +218,6 @@ def inline(model: onnx.ModelProto) -> _InlineCall:
     _signature_msg = f"signature {in_names}{_defaults_msg} -> {out_names}"
 
     model = _copy_model(model)
-    for node in model.graph.node:
-        for attr in node.attribute:
-            if attr.graphs:
-                raise ValueError(
-                    "Inlining models with variadic subgraph attributes is not supported."
-                )
     # FIXME: Support for functions is a bit involved, as it interacts with build.
     if model.functions:
         raise ValueError(

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -249,8 +249,8 @@ def test_relu_inline_subgraph(onnx_helper, relu_proto):
     (b,) = inline(relu_proto)(a).values()
     graph = results(b=b).with_arguments(a)
 
-    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=numpy.array([1.0])), 1.0)
-    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=numpy.array([-1.0])), 0.0)
+    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=numpy.array(1.0)), 1.0)
+    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=numpy.array(-1.0)), 0.0)
 
 
 def test_symbolic_dim_stripped(add4_graph):

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -244,13 +244,6 @@ def test_proj_composed_same_name(onnx_helper, proj_proto):
     )
 
 
-def test_relu_inline_subgraph_warns(onnx_helper, relu_proto):
-    (a,) = arguments(a=Tensor(float, ()))
-    with pytest.raises(ValueError):
-        inline(relu_proto)(a).values()
-
-
-@pytest.mark.skip("Inlining subgraphs requires reimplementing renaming in graphs.")
 def test_relu_inline_subgraph(onnx_helper, relu_proto):
     (a,) = arguments(a=Tensor(float, ()))
     (b,) = inline(relu_proto)(a).values()


### PR DESCRIPTION
Addresses #82 by avoiding adding extraneous Identity nodes when inlining and supporting subgraph renaming

- Reimplements the `onnx.compose.add_prefix_graph` to make it more flexible.
- Slightly expands Spox scopes to support 'anonymous' reserved names, which don't have an associated `Var`/`Node`, but are nevertheless marked as taken. This is because not all inlined nodes/values have a respective `Var`/`Node`.
