### PR TITLE
Allow creation of untyped variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.9.0 (2023-06-xx)
+------------------
+
+**New features**
+
+- ``argument`` can now take ``None``, indicating the argument variable is untyped.
+
+
 0.8.1 (2023-05-xx)
 ------------------
 

--- a/src/spox/_internal_op.py
+++ b/src/spox/_internal_op.py
@@ -64,7 +64,7 @@ class Argument(_InternalNode):
 
     @dataclass
     class Attributes(BaseAttributes):
-        type: AttrType
+        type: Optional[AttrType] = None
         name: Optional[AttrString] = None
         default: Optional[AttrTensor] = None
 
@@ -80,13 +80,17 @@ class Argument(_InternalNode):
     inputs: Inputs
     outputs: Outputs
 
+    @property
+    def untyped(self) -> bool:
+        return super().untyped or self.attrs.type is None
+
     def post_init(self, **kwargs):
         if self.attrs.name is not None:
             self.outputs.arg._rename(self.attrs.name.value)
 
     def infer_output_types(self) -> Dict[str, Type]:
         # Output type is based on the value of the type attribute
-        return {"arg": self.attrs.type.value}
+        return {"arg": self.attrs.type.value} if self.attrs.type else {}
 
     def update_metadata(self, opset_req, initializers, functions):
         super().update_metadata(opset_req, initializers, functions)

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -144,6 +144,10 @@ class Node(ABC):
         return {(self.op_type.domain, self.op_type.version)}
 
     @property
+    def untyped(self) -> bool:
+        return any(t is None for _, t in self._list_types(self.inputs))
+
+    @property
     def min_input(self) -> int:
         """
         Sets the minimum number of inputs in the ONNX representation.
@@ -247,6 +251,8 @@ class Node(ABC):
 
     def validate_types(self) -> None:
         """Validation of types, ran at the end of Node creation."""
+        if _TYPE_WARNING_LEVEL <= TypeWarningLevel.INITIAL and self.untyped:
+            return
         if _TYPE_WARNING_LEVEL <= TypeWarningLevel.NONE:
             return
         for name, value_type in self._list_types(self.outputs):

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -17,7 +17,7 @@ from ._type_system import Type
 from ._var import Var
 
 
-def argument(typ: Type) -> Var:
+def argument(typ: Optional[Type]) -> Var:
     """
     Create an argument variable which may be used as a model input.
 
@@ -25,6 +25,8 @@ def argument(typ: Type) -> Var:
     ----------
     typ
         The type of the created argument variable.
+        If ``None`` is passed, the variable is untyped.
+        This may be useful when defining ONNX functions.
 
     Returns
     -------
@@ -33,7 +35,7 @@ def argument(typ: Type) -> Var:
         a model input to build a graph.
     """
     return _internal_op.Argument(
-        _internal_op.Argument.Attributes(type=AttrType(typ), default=None)
+        _internal_op.Argument.Attributes(type=AttrType.maybe(typ), default=None)
     ).outputs.arg
 
 

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -86,3 +86,9 @@ def test_simple_inline_bad_types(simple_model):
         inline(simple_model)(b, a)
     with pytest.raises(TypeError):
         inline(simple_model)(a, c)
+
+
+def test_untyped_arguments_do_not_warn(recwarn):
+    x = argument(None)
+    op.add(x, x)
+    assert not recwarn

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -4,6 +4,7 @@ import pytest
 import spox.opset.ai.onnx.v17 as op
 from spox._exceptions import InferenceError
 from spox._graph import arguments
+from spox._public import argument
 from spox._type_system import Tensor
 
 
@@ -52,6 +53,12 @@ def test_inference_validation_fails():
     a, b = arguments(a=Tensor(numpy.float32, (2,)), b=Tensor(numpy.float64, (2,)))
     with pytest.raises(InferenceError):
         op.add(a, b)
+
+
+def test_untyped_arguments(recwarn):
+    x = argument(None)
+    op.add(x, x)
+    assert not recwarn
 
 
 def test_multiple_outputs():


### PR DESCRIPTION
This is a simple proposal to allow `argument(None)`, i.e. untyped arguments and hence variables. Such variables would have no type checking done.

The goal of this is to allow defining functions by defining a model like usual, but with untyped variables. This is because functions are not typed in ONNX at all. 

I think this is a start to getting rid of the whole facility related to `_function.Function` - as this is really messy when it interferes with the 'real' Spox graph - and move everything to a new `build`-like function which would construct a `FunctionProto`. 

The last two steps to refactor this would be to make sure attribute references work (`_attr.Ref`) and making `Function` just a thin wrapper around `FunctionProto` - or possibly remove `Function` entirely and piggyback off of `Inline` which could then support functions itself. 

For example, the goal would be to get something like:
```py
t = attribute_ref(int)  # Make a new attribute reference for this function
x = argument(None)  # Untyped arguments
y = argument(None)
z = op.add(x, y)  # Usual graph operators
w = op.mul(z, op.constant(value_int=t))  # Using the function attribute here
# List and name all attributes for this function
function: onnx.FunctionProto = build_function({"x": x, "y": y}, {"w": w}, {"t": t})  
# This might actually also need to return a list of FunctionProto objects, 
#  since functions may depend on each other and we have to manage those dependencies...

...

a = argument(Tensor(int, ()))
# inline_function - like normal inline, but takes a FunctionProto
#  (could be a thin wrapper on inline with support for functions)
#  type inference & checking can be implemented here by expanding the function body
(b,) = inline_function(function)(a, a)
# build collects the function_proto used in the graph and places it in the model
# manages any colliding function names by adding a discriminator
model = build({"a": a}, {"b": b})  
```
