### PR TITLE
Fix dtype aliasing removal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Change log
 **Bug fixes**
 
 - The constructor for ``ai.onnx@18::Split`` is no longer generated incorrectly. No extraneous attribute is generated anymore, and the ``num_outputs`` attribute is marked as required (so that Spox can infer the number of outputs).
+- Fix an issue where op.const handled numbers in the range(INT64MAX, UINT64MAX) incorrectly
 
 **Other changes**
 
@@ -56,7 +57,7 @@ This version is intended as a release candidate for ``1.0.0``.
 
 **Breaking changes**
 
-- The typing rules of the (previously partially documented) extra constructor ``const`` have changed. Its signature is now ``const(npt.ArrayLike, npt.DTypeLike = None) -> Var``. In particular, ``const`` of a Python ``float`` no longer becomes ``float32``, but ``float64`` like numpy - this is a **breaking change**. The operator is redefined to be equivalent to ``constant(numpy.array(value), dtype)``, instead of a complex set of cases like before. 
+- The typing rules of the (previously partially documented) extra constructor ``const`` have changed. Its signature is now ``const(npt.ArrayLike, npt.DTypeLike = None) -> Var``. In particular, ``const`` of a Python ``float`` no longer becomes ``float32``, but ``float64`` like numpy - this is a **breaking change**. The operator is redefined to be equivalent to ``constant(numpy.array(value), dtype)``, instead of a complex set of cases like before.
 - The ``Type <= Type`` (``Type.__le__``) overload is now removed.
 - Deprecated operator constructors are now no longer generated after the version their schema was deprecated. Effectively, this means ``ai.onnx@17::Scatter`` and ``ai.onnx@17::Upsample`` (available as ``op.scatter`` and ``op.upsample``) are no longer available in ``spox.opset.ai.onnx.v17``. They likely were not used in practice as attempting to build deprecated operators has always failed.
 

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -52,8 +52,12 @@ class PropValue:
 
     def __post_init__(self):
         # Fix dtype aliasing
-        if isinstance(self.value, numpy.ndarray) and numpy.issubdtype(self.value.dtype, numpy.number):
-            object.__setattr__(self, 'value', self.value.astype(numpy.dtype(self.value.dtype.name)))
+        if isinstance(self.value, numpy.ndarray) and numpy.issubdtype(
+            self.value.dtype, numpy.number
+        ):
+            object.__setattr__(
+                self, "value", self.value.astype(numpy.dtype(self.value.dtype.name))
+            )
 
         if VALUE_PROP_STRICT_CHECK and not self.check():
             raise ValueError(

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -51,10 +51,14 @@ class PropValue:
     value: PropValueType
 
     def __post_init__(self):
-        # Fix dtype aliasing
+        # The underlying numpy array might have been constructed with a
+        # platform-dependent dtype - such as ulonglong.
+        # Though very similar, it does not compare equal to the usual sized dtype.
+        # (for example ulonglong is not uint64)
         if isinstance(self.value, numpy.ndarray) and numpy.issubdtype(
             self.value.dtype, numpy.number
         ):
+            # We normalize by reconstructing the dtype through its name
             object.__setattr__(
                 self, "value", self.value.astype(numpy.dtype(self.value.dtype.name))
             )

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -51,6 +51,10 @@ class PropValue:
     value: PropValueType
 
     def __post_init__(self):
+        # Fix dtype aliasing
+        if isinstance(self.value, numpy.ndarray) and numpy.issubdtype(self.value.dtype, numpy.number):
+            object.__setattr__(self, 'value', self.value.astype(numpy.dtype(self.value.dtype.name)))
+
         if VALUE_PROP_STRICT_CHECK and not self.check():
             raise ValueError(
                 f"Attempt to construct PropValue of {self.value}, "
@@ -111,7 +115,6 @@ class PropValue:
             return cls(typ, [cls.from_ort_value(elem_type, elem) for elem in value])
         elif isinstance(value, numpy.ndarray):  # Tensor
             # Normalise the dtype in case we got an alias (like longlong)
-            value = value.astype(numpy.dtype(value.dtype.name))
             if value.dtype == numpy.dtype(object):
                 value = value.astype(str)
             return cls(typ, value)

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -151,3 +151,10 @@ def test_give_up_silently():
 
 def test_non_ascii_characters_in_string_tensor():
     op.cast(op.constant(value_string="FööBär"), to=str)
+
+
+def test_propagated_value_does_not_alias_dtype():
+    # Ensures that platform-dependent dtypes aren't accidentally propagated
+    x = numpy.iinfo(numpy.int64).max + 1
+    # Without the explicit astype(uint64), x actually ends up being ulonglong
+    assert_equal_value(op.const(x), numpy.array(x).astype(numpy.uint64))


### PR DESCRIPTION
Currently because of numpy type-aliasing there is type-inference error in this code:
```
op.const(np.iinfo(np.int64).max + 1)
```