### PR TITLE
Fix value-propagation for subgraphs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Change log
 **Other changes**
 
 - Inlining now no longer adds redundant ``Identity`` nodes and supports subgraphs, thanks to reimplementing the ONNX renaming routine.
-- Return value-propagation for subgraphs.
+- Value-propagation now works for ``op.if_``.
 
 0.8.1 (2023-05-xx)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Change log
 **Other changes**
 
 - Inlining now no longer adds redundant ``Identity`` nodes and supports subgraphs, thanks to reimplementing the ONNX renaming routine.
-
+- Return value-propagation for subgraphs.
 
 0.8.1 (2023-05-xx)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Change log
 **Other changes**
 
 - Inlining now no longer adds redundant ``Identity`` nodes and supports subgraphs, thanks to reimplementing the ONNX renaming routine.
-- Value-propagation now works for ``op.if_``.
+- Value-propagation now works for operators with subgraphs.
 
 0.8.1 (2023-05-xx)
 ------------------

--- a/src/spox/_standard.py
+++ b/src/spox/_standard.py
@@ -239,7 +239,7 @@ def _strip_dim_symbol(typ: Type, pred: Callable[[str], bool]) -> Type:
 
 def _make_actual_subgraph(_node: Node, _key: str, graph: "Graph") -> onnx.GraphProto:
     """
-    Just build the graph without any extra hastle.
+    Just build the graph without any extra hassle.
     This is slow, as it has to run the whole build process.
     """
     return graph.to_onnx()

--- a/src/spox/_standard.py
+++ b/src/spox/_standard.py
@@ -10,6 +10,7 @@ from onnx.defs import OpSchema
 
 from . import _value_prop
 from ._exceptions import InferenceError
+from ._graph import results
 from ._node import Node
 from ._schemas import SCHEMAS
 from ._scope import Scope
@@ -17,8 +18,6 @@ from ._shape import SimpleShape
 from ._type_system import Optional, Sequence, Tensor, Type
 from ._utils import from_array
 from ._value_prop import PropValueType
-from ._attributes import AttrGraph
-from ._graph import results
 
 if TYPE_CHECKING:
     from ._graph import Graph
@@ -80,7 +79,9 @@ class StandardNode(Node):
             # Subgraphs are not fully built for possibly significant performance gains.
             # However, this uses a trick so that they type correctly.
             # This may throw if we are building ``not with_subgraphs``.
-            build_subgraph = _make_dummy_subgraph if with_dummy_subgraphs else _make_actual_subgraph
+            build_subgraph = (
+                _make_dummy_subgraph if with_dummy_subgraphs else _make_actual_subgraph
+            )
             (node_proto,) = self.to_onnx(scope, build_subgraph=build_subgraph)
         finally:
             self.attrs = self_attrs
@@ -157,7 +158,7 @@ class StandardNode(Node):
         }
 
     def ready_for_value_propagation(self):
-        """ Checks if value propagation can be performed.
+        """Checks if value propagation can be performed.
         The check performed is to just construct a hypothetical model
         and see if it depends on any arguments.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,13 @@ import pytest
 
 from spox import _value_prop
 from spox._debug import show_construction_tracebacks
-from spox._future import set_type_warning_level
+from spox._future import (
+    ValuePropBackend,
+    set_type_warning_level,
+    set_value_prop_backend,
+)
 from spox._graph import Graph
 from spox._node import TypeWarningLevel
-from spox._future import set_value_prop_backend, ValuePropBackend
 
 set_value_prop_backend(ValuePropBackend.ONNXRUNTIME)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from spox._debug import show_construction_tracebacks
 from spox._future import set_type_warning_level
 from spox._graph import Graph
 from spox._node import TypeWarningLevel
+from spox._future import set_value_prop_backend, ValuePropBackend
+
+set_value_prop_backend(ValuePropBackend.ONNXRUNTIME)
 
 set_type_warning_level(TypeWarningLevel.CRITICAL)
 _value_prop.VALUE_PROP_STRICT_CHECK = True

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -440,9 +440,8 @@ def test_subgraph_argument_leak_caught():
         ii = i
         return [op.const(True), i]
 
-    (m,) = arguments(m=Tensor(int, ()))
-    (r,) = op.loop(M=m, v_initial=[], body=fun)
-    graph = results(_=op.add(r, ii))
-
     with pytest.raises(BuildError):
+        (m,) = arguments(m=Tensor(int, ()))
+        (r,) = op.loop(M=m, v_initial=[], body=fun)
+        graph = results(_=op.add(r, ii))
         graph.to_onnx_model()

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -131,6 +131,14 @@ def test_with_reconstruct():
     )
 
 
+def test_if():
+    (a,) = op.if_(op.const(True), then_branch=lambda: [op.const([1, 2, 3])], else_branch=lambda: [op.const([4, 5])])
+    assert_equal_value(
+        a,
+        numpy.array([1, 2, 3])
+    )
+
+
 def test_bad_reshape_fails(caplog):
     caplog.set_level("DEBUG")
     _ = op.reshape(op.const([1, 2]), op.const([2]))  # sanity

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -139,6 +139,37 @@ def test_if():
     )
 
 
+def test_loop():
+    (r,) = op.loop(
+        M=op.const([5]),
+        v_initial=[],
+        body=lambda i, _: (
+            op.const(numpy.array(True)),
+            op.if_(
+                op.greater_or_equal(i, op.const(2)),
+                else_branch=lambda: [op.const([2])],
+                then_branch=lambda: [i],
+            )[0],
+        ),
+    )
+    assert_equal_value(
+        r,
+        numpy.array([[2], [2], [2], [3], [4]])
+    )
+
+
+def test_scan_prod():
+    arr = numpy.array([1, 2, 3, 4, 5])
+    x = op.const(arr)
+    one = op.const(numpy.array(1, dtype=numpy.int64))
+    prod, _x = op.scan([one, x], body=lambda a, p: [op.mul(a, p), a], num_scan_inputs=1)
+    print(prod)
+    assert_equal_value(
+        prod,
+        numpy.prod(arr)
+    )
+
+
 def test_bad_reshape_fails(caplog):
     caplog.set_level("DEBUG")
     _ = op.reshape(op.const([1, 2]), op.const([2]))  # sanity

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -132,11 +132,12 @@ def test_with_reconstruct():
 
 
 def test_if():
-    (a,) = op.if_(op.const(True), then_branch=lambda: [op.const([1, 2, 3])], else_branch=lambda: [op.const([4, 5])])
-    assert_equal_value(
-        a,
-        numpy.array([1, 2, 3])
+    (a,) = op.if_(
+        op.const(True),
+        then_branch=lambda: [op.const([1, 2, 3])],
+        else_branch=lambda: [op.const([4, 5])],
     )
+    assert_equal_value(a, numpy.array([1, 2, 3]))
 
 
 def test_loop():
@@ -152,10 +153,7 @@ def test_loop():
             )[0],
         ),
     )
-    assert_equal_value(
-        r,
-        numpy.array([[2], [2], [2], [3], [4]])
-    )
+    assert_equal_value(r, numpy.array([[2], [2], [2], [3], [4]]))
 
 
 def test_scan_prod():
@@ -164,10 +162,7 @@ def test_scan_prod():
     one = op.const(numpy.array(1, dtype=numpy.int64))
     prod, _x = op.scan([one, x], body=lambda a, p: [op.mul(a, p), a], num_scan_inputs=1)
     print(prod)
-    assert_equal_value(
-        prod,
-        numpy.prod(arr)
-    )
+    assert_equal_value(prod, numpy.prod(arr))
 
 
 def test_bad_reshape_fails(caplog):


### PR DESCRIPTION
Change the way value-propagation works in regards to operators with subgraphs. 

This was currently missing as value-propagation on subgraphs seems to be slow, however as it is an optional feature in my opinion we should strive for completeness instead of performance.