### PR TITLE
Fix bug where node adaption failed for nodes with repeated inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.9.1 (2023-xx-xx)
+------------------
+
+**Bug fix**
+
+- The node-adaption no longer fails if faced with a node that has repeating inputs.
+
+
 0.9.0 (2023-06-12)
 ------------------
 

--- a/src/spox/_adapt.py
+++ b/src/spox/_adapt.py
@@ -25,12 +25,14 @@ def adapt_node(
         return None
 
     try:
-        input_info = [
-            var.unwrap_type()._to_onnx_value_info(
+        # By using a dictionary we ensure that we only have a single
+        # ValueInfo per (possibly repeated) input name.
+        input_info = {
+            var_names[var]: var.unwrap_type()._to_onnx_value_info(
                 var_names[var], _traceback_name=f"adapt-input {key}"
             )
             for key, var in node.inputs.get_vars().items()
-        ]
+        }
         output_info = [
             var.unwrap_type()._to_onnx_value_info(
                 var_names[var], _traceback_name=f"adapt-output {key}"
@@ -49,7 +51,7 @@ def adapt_node(
         onnx.helper.make_graph(
             [proto],
             "spox__singleton_adapter_graph",
-            input_info,
+            list(input_info.values()),
             output_info,
             initializers,
         ),

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -6,14 +6,14 @@ import onnx
 import onnx.parser
 import pytest
 
+import spox.opset.ai.onnx.v18 as op18
+import spox.opset.ai.onnx.v19 as op19
+from spox import Tensor, Var, argument, build, inline
 from spox._attributes import AttrInt64s
 from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
 from spox._graph import arguments, results
 from spox._node import OpType
-from spox._public import inline
 from spox._standard import StandardNode
-from spox._type_system import Tensor
-from spox._var import Var
 
 
 @pytest.fixture
@@ -141,3 +141,11 @@ def test_adapts_singleton_old_squeeze(onnx_helper, old_squeeze_graph):
         ),
         [1, 2, 3, 4],
     )
+
+
+def test_adapt_node_with_repeating_input_names():
+    a = argument(Tensor(numpy.float32, ("N",)))
+    b = op18.equal(a, a)
+    c = op19.identity(a)
+
+    build({"a": a}, {"b": b, "c": c})


### PR DESCRIPTION
Node-adaption currently fails if the adapted node has repeating inputs (e.g. the result of `op.equal(a, a)`). This PR addresses that issue.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
