### PR TITLE
Run CI on all commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
- pull_request:
- push:
-   branches:
-    - main
+on: push
 
 defaults:
   run:


### PR DESCRIPTION
CI on this repository is quite quick and cheap/free. If we run it on every commit then one can know that the CI passes before opening a PR.
