### PR TITLE
Migrate from setuptools/pkg_resources to importlib

### DIFF
--- a/src/spox/__init__.py
+++ b/src/spox/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.metadata
 
 from spox._public import argument, build, inline
 from spox._type_system import Optional, Sequence, Tensor, Type
@@ -16,6 +16,6 @@ __all__ = [
 ]
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
+    __version__ = importlib.metadata.distribution(__name__).version
 except Exception:
     __version__ = "unknown"


### PR DESCRIPTION
The usage of `pkg_resources` is deprecated. Using `importlib` is recommended instead. 
