### PR TITLE
Pass types for repeated containers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change log
 
 - The opsets ``ai.onnx`` version 20 and ``ai.onnx.ml`` version 4 (ONNX 1.15) are now shipped with Spox.
 
+**Other changes**
+
+- The validation of Node attributes has been improved and more consistent exceptions are raised if needed.
+
 
 0.9.3 (2023-10-23)
 ------------------

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -120,7 +120,10 @@ class AttrTensor(Attr[np.ndarray]):
         super().__init__(value.copy())
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
-        return make_attribute(key, from_array(self.value))
+        return make_attribute(
+            key,
+            from_array(self.value),
+        )
 
 
 class AttrType(Attr[_type_system.Type]):
@@ -188,21 +191,23 @@ class AttrFloat32s(_AttrIterable[float]):
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         # ensure values are all floats
         values = [float(v) for v in self.value]
-        return make_attribute(key, values)
+        return make_attribute(key, values, attr_type=AttributeProto.FLOATS)
 
 
 class AttrInt64s(_AttrIterable[int]):
     _attribute_proto_type_int = AttributeProto.INTS
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
-        return make_attribute(key, self.value)
+        return make_attribute(key, self.value, attr_type=AttributeProto.INTS)
 
 
 class AttrStrings(_AttrIterable[str]):
     _attribute_proto_type_int = AttributeProto.STRINGS
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
-        return make_attribute(key, [v.encode() for v in self.value])
+        return make_attribute(
+            key, [v.encode() for v in self.value], attr_type=AttributeProto.STRINGS
+        )
 
 
 class AttrTensors(_AttrIterable[np.ndarray]):
@@ -210,7 +215,7 @@ class AttrTensors(_AttrIterable[np.ndarray]):
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         tensors = [from_array(t) for t in self.value]
-        return make_attribute(key, tensors)
+        return make_attribute(key, tensors, attr_type=AttributeProto.TENSORS)
 
 
 def _deref(ref: _Ref[T]) -> T:

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -1,15 +1,6 @@
+import abc
 from abc import ABC
-from typing import (
-    Any,
-    ClassVar,
-    Generic,
-    Iterable,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, Generic, Iterable, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -32,7 +23,6 @@ AttrIterableT = TypeVar("AttrIterableT", bound="_AttrIterable")
 
 class Attr(ABC, Generic[T]):
     _value: Union[T, "_Ref[T]"]
-    _attribute_proto_type_int: ClassVar[int]
 
     def __init__(self, value: Union[T, "_Ref[T]"]):
         self._value = value
@@ -50,19 +40,41 @@ class Attr(ABC, Generic[T]):
         return self._value
 
     def _validate(self):
-        if self._to_onnx("dummy").type != self._attribute_proto_type_int:
-            raise TypeError(
-                f"Unable to instantiate `{type(self).__name__}` with value of type `{type(self.value).__name__}`."
-            )
+        try:
+            type_in_onnx = self._to_onnx_deref("dummy").type
+        except Exception as e:
+            # Likely an error from within onnx/protobuf, such as:
+            # 1) AttributeError: 'int' object has no attribute 'encode'
+            # 2) TypeError: 'a' has type str, but expected one of: int -- this is raised from within protobuf
+            # when .extend()-ing with the wrong type.
+            raise self._get_pretty_type_exception() from e
+
+        if type_in_onnx != self._attribute_proto_type:
+            raise self._get_pretty_type_exception()
 
     def _to_onnx(self, key: str) -> AttributeProto:
         if isinstance(self._value, _Ref):
             return self._value._to_onnx(key)
         return self._to_onnx_deref(key)
 
+    @property
+    @abc.abstractmethod
+    def _attribute_proto_type(self) -> int:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         """Conversion method for the dereferenced case."""
-        raise NotImplementedError
+        raise NotImplementedError()
+
+    def _get_pretty_type_exception(self):
+        if isinstance(self.value, tuple) and len(self.value):
+            types = ", ".join(sorted({type(v).__name__ for v in self.value}))
+            msg = f"Unable to instantiate `{type(self).__name__}` from items of type(s) `{types}`."
+        else:
+            ty = type(self.value).__name__
+            msg = f"Unable to instantiate `{type(self).__name__}` with value of type `{ty}`."
+        return TypeError(msg)
 
 
 class _Ref(Generic[T]):
@@ -90,7 +102,7 @@ class _Ref(Generic[T]):
 
 
 class AttrFloat32(Attr[float]):
-    _attribute_proto_type_int = AttributeProto.FLOAT
+    _attribute_proto_type = AttributeProto.FLOAT
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         if isinstance(self.value, int):
@@ -99,35 +111,31 @@ class AttrFloat32(Attr[float]):
 
 
 class AttrInt64(Attr[int]):
-    _attribute_proto_type_int = AttributeProto.INT
+    _attribute_proto_type = AttributeProto.INT
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         return make_attribute(key, self.value)
 
 
 class AttrString(Attr[str]):
-    _attribute_proto_type_int = AttributeProto.STRING
+    _attribute_proto_type = AttributeProto.STRING
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
-        # Strings are bytes on the onnx side
-        return make_attribute(key, self.value.encode())
+        return make_attribute(key, self.value)
 
 
 class AttrTensor(Attr[np.ndarray]):
-    _attribute_proto_type_int = AttributeProto.TENSOR
+    _attribute_proto_type = AttributeProto.TENSOR
 
     def __init__(self, value: Union[np.ndarray, _Ref[np.ndarray]]):
         super().__init__(value.copy())
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
-        return make_attribute(
-            key,
-            from_array(self.value),
-        )
+        return make_attribute(key, from_array(self.value))
 
 
 class AttrType(Attr[_type_system.Type]):
-    _attribute_proto_type_int = AttributeProto.TYPE_PROTO
+    _attribute_proto_type = AttributeProto.TYPE_PROTO
 
     def _to_onnx_deref(self, key: str) -> AttributeProto:
         value = self.value  # for type-checkers with limited property support
@@ -141,14 +149,14 @@ class AttrType(Attr[_type_system.Type]):
         elif isinstance(value, _type_system.Optional):
             type_proto = make_optional_type_proto(value.elem_type._to_onnx())
         else:
-            raise NotImplementedError
+            raise NotImplementedError()
         return make_attribute(key, type_proto)
 
 
 class AttrDtype(Attr[npt.DTypeLike]):
     """Special attribute for specifying data types as ``numpy.dtype``s, for example in ``Cast``."""
 
-    _attribute_proto_type_int = AttributeProto.INT
+    _attribute_proto_type = AttributeProto.INT
 
     def _validate(self):
         dtype_to_tensor_type(self.value)
@@ -158,7 +166,7 @@ class AttrDtype(Attr[npt.DTypeLike]):
 
 
 class AttrGraph(Attr[Any]):
-    _attribute_proto_type_int = AttributeProto.GRAPH
+    _attribute_proto_type = AttributeProto.GRAPH
 
     def _validate(self):
         from spox._graph import Graph
@@ -184,38 +192,24 @@ class _AttrIterable(Attr[Tuple[S, ...]], ABC):
     ) -> Optional[AttrIterableT]:
         return cls(tuple(value)) if value is not None else None
 
+    def _to_onnx_deref(self, key: str) -> AttributeProto:
+        return make_attribute(key, self.value, attr_type=self._attribute_proto_type)
+
 
 class AttrFloat32s(_AttrIterable[float]):
-    _attribute_proto_type_int = AttributeProto.FLOATS
-
-    def _to_onnx_deref(self, key: str) -> AttributeProto:
-        # ensure values are all floats
-        values = [float(v) for v in self.value]
-        return make_attribute(key, values, attr_type=AttributeProto.FLOATS)
+    _attribute_proto_type = AttributeProto.FLOATS
 
 
 class AttrInt64s(_AttrIterable[int]):
-    _attribute_proto_type_int = AttributeProto.INTS
-
-    def _to_onnx_deref(self, key: str) -> AttributeProto:
-        return make_attribute(key, self.value, attr_type=AttributeProto.INTS)
+    _attribute_proto_type = AttributeProto.INTS
 
 
 class AttrStrings(_AttrIterable[str]):
-    _attribute_proto_type_int = AttributeProto.STRINGS
-
-    def _to_onnx_deref(self, key: str) -> AttributeProto:
-        return make_attribute(
-            key, [v.encode() for v in self.value], attr_type=AttributeProto.STRINGS
-        )
+    _attribute_proto_type = AttributeProto.STRINGS
 
 
 class AttrTensors(_AttrIterable[np.ndarray]):
-    _attribute_proto_type_int = AttributeProto.TENSORS
-
-    def _to_onnx_deref(self, key: str) -> AttributeProto:
-        tensors = [from_array(t) for t in self.value]
-        return make_attribute(key, tensors, attr_type=AttributeProto.TENSORS)
+    _attribute_proto_type = AttributeProto.TENSORS
 
 
 def _deref(ref: _Ref[T]) -> T:

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -1,6 +1,9 @@
+import re
+
 import numpy
 import pytest
 
+import spox.opset.ai.onnx.ml.v3 as ml
 import spox.opset.ai.onnx.v17 as op
 from spox._exceptions import InferenceError
 from spox._graph import arguments
@@ -61,3 +64,37 @@ def test_multiple_outputs():
     values, indices = op.top_k(x, k)
     assert values.unwrap_type()._subtype(Tensor(numpy.float32, ("N", "M", None)))
     assert indices.unwrap_type()._subtype(Tensor(numpy.int64, ("N", "M", None)))
+
+
+def test_passing_wrong_type():
+    with pytest.raises(TypeError):
+        ml.label_encoder(
+            X=op.constant(value_ints=["a"]),  # type: ignore
+            keys_int64s=[0],
+            values_strings=["a"],
+            default_string="?",
+        )
+
+    with pytest.raises(TypeError):
+        ml.label_encoder(
+            op.constant(value_ints=[0]),
+            keys_int64s=["a"],  # type: ignore
+            values_strings=["a"],
+            default_string="?",
+        )
+
+    with pytest.raises(AttributeError, match=re.escape("has no attribute 'encode'")):
+        ml.label_encoder(
+            op.constant(value_ints=[0]),
+            keys_int64s=[0],
+            values_strings=[0],  # type: ignore
+            default_string="?",
+        )
+
+    with pytest.raises(AttributeError, match=re.escape("has no attribute 'encode'")):
+        ml.label_encoder(
+            op.constant(value_ints=[0]),
+            keys_int64s=[0],
+            values_strings=["a"],
+            default_string=0,  # type: ignore
+        )


### PR DESCRIPTION
The most time-consuming thing in `make_attribute` is iterating the values. By passing the attribute type, we save [one pass](https://github.com/onnx/onnx/blob/b60f69412abb5393ab819b936b473f83867f6c87/onnx/helper.py#L881), which could run 10-30% faster (depending on the amount of other work done).

```python
string_bytes = ["1".encode() for _ in range(5_000_000)]
%timeit make_attribute("key", string_bytes, attr_type=AttributeProto.STRINGS)
# 480 ms ± 8.67 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit make_attribute("key", string_bytes)
# 544 ms ± 5.09 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

ints = [1 for _ in range(5_000_000)]
%timeit make_attribute("key", ints, attr_type=AttributeProto.INTS)
# 172 ms ± 2.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit make_attribute("key", ints)
# 244 ms ± 4.02 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```