### PR TITLE
More fine-grained validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,10 @@ Change log
 **New feature**
 
 - The opsets ``ai.onnx`` version 20 and ``ai.onnx.ml`` version 4 (ONNX 1.15) are now shipped with Spox.
-- More consistent exceptions thrown for type errors with node attributes - now we raise AttributeTypeError (a subclass of TypeError).
+
+**Other changes**
+
+- The validation of Node attributes has been improved and more consistent exceptions are raised if needed.
 
 
 0.9.3 (2023-10-23)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change log
 **New feature**
 
 - The opsets ``ai.onnx`` version 20 and ``ai.onnx.ml`` version 4 (ONNX 1.15) are now shipped with Spox.
+- More consistent exceptions thrown for type errors with node attributes - now we raise AttributeTypeError (a subclass of TypeError).
 
 
 0.9.3 (2023-10-23)

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -21,7 +21,7 @@ AttrT = TypeVar("AttrT", bound="Attr")
 AttrIterableT = TypeVar("AttrIterableT", bound="_AttrIterable")
 
 
-class AttributeTypeError(TypeError):
+class OnnxAttributeTypeError(TypeError):
     """Raised upon encountering type errors in node attributes."""
 
     pass
@@ -79,7 +79,7 @@ class Attr(ABC, Generic[T]):
             value_type = f"tuple[{tuple_types}, ...]"
         else:
             value_type = type(self.value).__name__
-        return AttributeTypeError(
+        return OnnxAttributeTypeError(
             f"Unable to instantiate `{type(self).__name__}` with value of type `{value_type}`."
         )
 

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -69,13 +69,12 @@ class Attr(ABC, Generic[T]):
 
     def _get_pretty_type_exception(self):
         if isinstance(self.value, tuple) and len(self.value):
-            tuple_types = " | ".join(sorted({type(v).__name__ for v in self.value}))
-            value_type = f"tuple[{tuple_types}, ...]"
+            types = ", ".join(sorted({type(v).__name__ for v in self.value}))
+            msg = f"Unable to instantiate `{type(self).__name__}` from items of type(s) `{types}`."
         else:
-            value_type = type(self.value).__name__
-        return TypeError(
-            f"Unable to instantiate `{type(self).__name__}` with value of type `{value_type}`."
-        )
+            ty = type(self.value).__name__
+            msg = f"Unable to instantiate `{type(self).__name__}` with value of type `{ty}`."
+        return TypeError(msg)
 
 
 class _Ref(Generic[T]):

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -76,7 +76,7 @@ class Attr(ABC, Generic[T]):
 
     def _get_pretty_type_exception(self):
         if isinstance(self.value, tuple) and len(self.value):
-            tuple_types = ", ".join({type(v).__name__ for v in self.value})
+            tuple_types = " | ".join(sorted({type(v).__name__ for v in self.value}))
             value_type = f"tuple[{tuple_types}, ...]"
         else:
             value_type = type(self.value).__name__

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -21,12 +21,6 @@ AttrT = TypeVar("AttrT", bound="Attr")
 AttrIterableT = TypeVar("AttrIterableT", bound="_AttrIterable")
 
 
-class OnnxAttributeTypeError(TypeError):
-    """Raised upon encountering type errors in node attributes."""
-
-    pass
-
-
 class Attr(ABC, Generic[T]):
     _value: Union[T, "_Ref[T]"]
 
@@ -79,7 +73,7 @@ class Attr(ABC, Generic[T]):
             value_type = f"tuple[{tuple_types}, ...]"
         else:
             value_type = type(self.value).__name__
-        return OnnxAttributeTypeError(
+        return TypeError(
             f"Unable to instantiate `{type(self).__name__}` with value of type `{value_type}`."
         )
 

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -1,7 +1,9 @@
+import re
+from typing import Any
+
 import numpy
 import pytest
 
-import spox.opset.ai.onnx.ml.v3 as ml
 import spox.opset.ai.onnx.v17 as op
 from spox._attributes import AttributeTypeError
 from spox._exceptions import InferenceError
@@ -65,35 +67,23 @@ def test_multiple_outputs():
     assert indices.unwrap_type()._subtype(Tensor(numpy.int64, ("N", "M", None)))
 
 
-def test_passing_wrong_type():
-    with pytest.raises(AttributeTypeError):
-        ml.label_encoder(
-            X=op.constant(value_ints=["a"]),  # type: ignore
-            keys_int64s=[0],
-            values_strings=["a"],
-            default_string="?",
-        )
-
-    with pytest.raises(AttributeTypeError):
-        ml.label_encoder(
-            op.constant(value_ints=[0]),
-            keys_int64s=["a"],  # type: ignore
-            values_strings=["a"],
-            default_string="?",
-        )
-
-    with pytest.raises(AttributeTypeError):
-        ml.label_encoder(
-            op.constant(value_ints=[0]),
-            keys_int64s=[0],
-            values_strings=[0],  # type: ignore
-            default_string="?",
-        )
-
-    with pytest.raises(AttributeTypeError):
-        ml.label_encoder(
-            op.constant(value_ints=[0]),
-            keys_int64s=[0],
-            values_strings=["a"],
-            default_string=0,  # type: ignore
-        )
+@pytest.mark.parametrize(
+    "key,values,match",
+    [
+        (
+            "value_ints",
+            ["a"],
+            "Unable to instantiate `AttrInt64s` with value of type `tuple[str, ...]`",
+        ),
+        ("value_strings", [1], "Attribute values don't seem to be strings."),
+        ("value_floats", ["a"], "Attribute values don't seem to be floats."),
+        (
+            "value_int",
+            "a",
+            "Unable to instantiate `AttrInt64` with value of type `str`.",
+        ),
+    ],
+)
+def test_passing_wrong_type(key: str, values: Any, match: str):
+    with pytest.raises(AttributeTypeError, match=re.escape(match)):
+        op.constant(**{key: values})

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -75,8 +75,16 @@ def test_multiple_outputs():
             ["a"],
             "Unable to instantiate `AttrInt64s` with value of type `tuple[str, ...]`",
         ),
-        ("value_strings", [1], "Attribute values don't seem to be strings."),
-        ("value_floats", ["a"], "Attribute values don't seem to be floats."),
+        (
+            "value_strings",
+            [1],
+            "Unable to instantiate `AttrStrings` with value of type `tuple[int, ...]",
+        ),
+        (
+            "value_floats",
+            ["a"],
+            "Unable to instantiate `AttrFloat32s` with value of type `tuple[str, ...]",
+        ),
         (
             "value_int",
             "a",
@@ -92,6 +100,8 @@ def test_passing_wrong_type(key: str, values: Any, match: str):
 def test_passing_wrong_type_tensors():
     with pytest.raises(
         AttributeTypeError,
-        match=re.escape("Attribute values don't seem to be numpy arrays."),
+        match=re.escape(
+            "Unable to instantiate `AttrTensors` with value of type `tuple[int, ...]"
+        ),
     ):
         AttrTensors([1])  # type: ignore

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -5,7 +5,7 @@ import numpy
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
-from spox._attributes import AttributeTypeError
+from spox._attributes import AttributeTypeError, AttrTensors
 from spox._exceptions import InferenceError
 from spox._graph import arguments
 from spox._type_system import Tensor
@@ -87,3 +87,11 @@ def test_multiple_outputs():
 def test_passing_wrong_type(key: str, values: Any, match: str):
     with pytest.raises(AttributeTypeError, match=re.escape(match)):
         op.constant(**{key: values})
+
+
+def test_passing_wrong_type_tensors():
+    with pytest.raises(
+        AttributeTypeError,
+        match=re.escape("Attribute values don't seem to be numpy arrays."),
+    ):
+        AttrTensors([1])  # type: ignore

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -5,7 +5,7 @@ import numpy
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
-from spox._attributes import AttrTensors, OnnxAttributeTypeError
+from spox._attributes import AttrTensors
 from spox._exceptions import InferenceError
 from spox._graph import arguments
 from spox._type_system import Tensor
@@ -93,13 +93,13 @@ def test_multiple_outputs():
     ],
 )
 def test_passing_wrong_type(key: str, values: Any, match: str):
-    with pytest.raises(OnnxAttributeTypeError, match=re.escape(match)):
+    with pytest.raises(TypeError, match=re.escape(match)):
         op.constant(**{key: values})
 
 
 def test_passing_wrong_type_tensors():
     with pytest.raises(
-        OnnxAttributeTypeError,
+        TypeError,
         match=re.escape(
             "Unable to instantiate `AttrTensors` with value of type `tuple[int, ...]"
         ),

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -5,7 +5,7 @@ import numpy
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
-from spox._attributes import AttributeTypeError, AttrTensors
+from spox._attributes import AttrTensors, OnnxAttributeTypeError
 from spox._exceptions import InferenceError
 from spox._graph import arguments
 from spox._type_system import Tensor
@@ -93,13 +93,13 @@ def test_multiple_outputs():
     ],
 )
 def test_passing_wrong_type(key: str, values: Any, match: str):
-    with pytest.raises(AttributeTypeError, match=re.escape(match)):
+    with pytest.raises(OnnxAttributeTypeError, match=re.escape(match)):
         op.constant(**{key: values})
 
 
 def test_passing_wrong_type_tensors():
     with pytest.raises(
-        AttributeTypeError,
+        OnnxAttributeTypeError,
         match=re.escape(
             "Unable to instantiate `AttrTensors` with value of type `tuple[int, ...]"
         ),

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -73,17 +73,17 @@ def test_multiple_outputs():
         (
             "value_ints",
             ["a"],
-            "Unable to instantiate `AttrInt64s` with value of type `tuple[str, ...]`",
+            "Unable to instantiate `AttrInt64s` from items of type(s) `str`.",
         ),
         (
             "value_strings",
-            [1],
-            "Unable to instantiate `AttrStrings` with value of type `tuple[int, ...]",
+            [1, 2.3],
+            "Unable to instantiate `AttrStrings` from items of type(s) `float, int`.",
         ),
         (
             "value_floats",
             ["a"],
-            "Unable to instantiate `AttrFloat32s` with value of type `tuple[str, ...]",
+            "Unable to instantiate `AttrFloat32s` from items of type(s) `str`.",
         ),
         (
             "value_int",
@@ -101,7 +101,7 @@ def test_passing_wrong_type_tensors():
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "Unable to instantiate `AttrTensors` with value of type `tuple[int, ...]"
+            "Unable to instantiate `AttrTensors` from items of type(s) `int`."
         ),
     ):
         AttrTensors([1])  # type: ignore

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -1,10 +1,9 @@
-import re
-
 import numpy
 import pytest
 
 import spox.opset.ai.onnx.ml.v3 as ml
 import spox.opset.ai.onnx.v17 as op
+from spox._attributes import AttributeTypeError
 from spox._exceptions import InferenceError
 from spox._graph import arguments
 from spox._type_system import Tensor
@@ -67,7 +66,7 @@ def test_multiple_outputs():
 
 
 def test_passing_wrong_type():
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeTypeError):
         ml.label_encoder(
             X=op.constant(value_ints=["a"]),  # type: ignore
             keys_int64s=[0],
@@ -75,7 +74,7 @@ def test_passing_wrong_type():
             default_string="?",
         )
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeTypeError):
         ml.label_encoder(
             op.constant(value_ints=[0]),
             keys_int64s=["a"],  # type: ignore
@@ -83,7 +82,7 @@ def test_passing_wrong_type():
             default_string="?",
         )
 
-    with pytest.raises(AttributeError, match=re.escape("has no attribute 'encode'")):
+    with pytest.raises(AttributeTypeError):
         ml.label_encoder(
             op.constant(value_ints=[0]),
             keys_int64s=[0],
@@ -91,7 +90,7 @@ def test_passing_wrong_type():
             default_string="?",
         )
 
-    with pytest.raises(AttributeError, match=re.escape("has no attribute 'encode'")):
+    with pytest.raises(AttributeTypeError):
         ml.label_encoder(
             op.constant(value_ints=[0]),
             keys_int64s=[0],


### PR DESCRIPTION
Please share your thoughts on this. It's solving a few problems:
- ~30% speedup when instantiating (noticeable in operators with big attributes)~ - we would like to try end-to-end caching first, which should give us a bigger speedup
- Addressing https://github.com/Quantco/spox/pull/119#issuecomment-1827399762 : consistent exception source when spox attribute type checks fail. ~Note we had to omit the call to `.encode()` in the string-like attributes ([ONNX's make_attribute takes care of that](https://github.com/onnx/onnx/blob/5be7f3164ba0b2c323813264ceb0ae7e929d2350/onnx/helper.py#L906)).~ We are now [catching this error](https://github.com/Quantco/spox/blob/4918f3e303d1ca7dc5d87fdbf53b7449fac95d39/src/spox/_attributes.py#L228-L236)
- Custom exception

## TODOs

1. [x] TODO in code: make sure we never use the actual attribute proto, just its type, in the `_Ref` class
2. [x] TODO in code: is there a more elegant way to implement `_deduce_type`, and is the copy-paste worth it
3. [x] Added a `CHANGELOG.rst` entry

## ~Speedup~ (not included in this PR in favour of future caching efforts)
Before:
<img width="695" alt="image" src="https://github.com/Quantco/spox/assets/84503892/041c5c3b-5d61-4b6d-b79b-f30df735b761">

Now:
<img width="721" alt="image" src="https://github.com/Quantco/spox/assets/84503892/715eb43a-9ee5-4fd7-8c2d-f69cb32d438b">
