### PR TITLE
Expose `initializer` primitive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change log
 **New feature**
 
 - The opsets ``ai.onnx`` version 20 and ``ai.onnx.ml`` version 4 (ONNX 1.15) are now shipped with Spox.
+- The ``initializer`` primitive has been exposed.
 
 **Other changes**
 

--- a/src/spox/__init__.py
+++ b/src/spox/__init__.py
@@ -1,6 +1,6 @@
 import importlib.metadata
 
-from spox._public import argument, build, inline
+from spox._public import argument, build, initializer, inline
 from spox._type_system import Optional, Sequence, Tensor, Type
 from spox._var import Var
 
@@ -11,6 +11,7 @@ __all__ = [
     "Sequence",
     "Optional",
     "argument",
+    "initializer",
     "build",
     "inline",
 ]

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -4,11 +4,9 @@ from contextlib import contextmanager
 from typing import Iterable, List, Optional, Union
 
 import numpy as np
-import numpy.typing as npt
 
 import spox._node
 import spox._value_prop
-from spox._graph import initializer as _initializer
 from spox._type_system import Tensor
 from spox._var import Var
 
@@ -40,32 +38,6 @@ def value_prop_backend(backend: ValuePropBackend):
     set_value_prop_backend(backend)
     yield
     set_value_prop_backend(prev_backend)
-
-
-def initializer(value: npt.ArrayLike, dtype: npt.DTypeLike = None) -> Var:
-    """
-    Create a Var with a constant value.
-
-    Parameters
-    ----------
-    value
-        Array-like value for the variable.
-    dtype
-        Data type for the given value. If ``None``, it is inferred from the value
-        using numpy rules (``numpy.array(value)``).
-
-    Returns
-    -------
-    Var
-        Variable with the given constant ``value``.
-
-    Notes
-    -----
-    When the model is built, constants created by this function become initializers.
-    As such, they are independent of an opset version and are listed separately
-    in the model. Initializers are also used internally in Spox.
-    """
-    return _initializer(np.array(value, dtype))
 
 
 class _NumpyLikeOperatorDispatcher:
@@ -210,8 +182,6 @@ __all__ = [
     "TypeWarningLevel",
     "set_type_warning_level",
     "type_warning_level",
-    # Initializer-backed constants
-    "initializer",
     # Value propagation backend
     "ValuePropBackend",
     "set_value_prop_backend",

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -61,7 +61,8 @@ def initializer(value: npt.ArrayLike, dtype: npt.DTypeLike = None) -> Var:
     -----
     When the model is built, constants created by this function become initializers.
     As such, they are independent of an opset version and are listed separately
-    in the model. Initializers are also used internally in Spox.
+    in the model. Initializers are also used internally in Spox. Currently it is not
+    possible for initializers to be named the same as arguments in the graph.
     """
     return _initializer(np.array(value, dtype))
 

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -5,12 +5,15 @@ import itertools
 from typing import Dict, List, Optional, Protocol
 
 import numpy as np
+import numpy.typing as npt
 import onnx
 from onnx.numpy_helper import to_array
 
 from . import _internal_op
 from ._attributes import AttrType
-from ._graph import Argument, initializer, results
+from ._graph import Argument
+from ._graph import initializer as _initializer
+from ._graph import results
 from ._inline import _Inline
 from ._standard import _strip_dim_symbol
 from ._type_system import Type
@@ -35,6 +38,32 @@ def argument(typ: Type) -> Var:
     return _internal_op.Argument(
         _internal_op.Argument.Attributes(type=AttrType(typ, "dummy"), default=None)
     ).outputs.arg
+
+
+def initializer(value: npt.ArrayLike, dtype: npt.DTypeLike = None) -> Var:
+    """
+    Create a Var with a constant value.
+
+    Parameters
+    ----------
+    value
+        Array-like value for the variable.
+    dtype
+        Data type for the given value. If ``None``, it is inferred from the value
+        using numpy rules (``numpy.array(value)``).
+
+    Returns
+    -------
+    Var
+        Variable with the given constant ``value``.
+
+    Notes
+    -----
+    When the model is built, constants created by this function become initializers.
+    As such, they are independent of an opset version and are listed separately
+    in the model. Initializers are also used internally in Spox.
+    """
+    return _initializer(np.array(value, dtype))
 
 
 @contextlib.contextmanager
@@ -284,4 +313,4 @@ def inline(model: onnx.ModelProto) -> _InlineCall:
     return inline_inner
 
 
-__all__ = ["argument", "build", "inline"]
+__all__ = ["argument", "initializer", "build", "inline"]

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -4,7 +4,7 @@ from typing import Any, List
 import numpy
 import pytest
 
-from spox._future import initializer
+from spox import initializer
 
 TESTED_INITIALIZER_ROWS: List[List[Any]] = [
     [0, 1, 2],

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -4,9 +4,8 @@ import numpy
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
-from spox import Var
+from spox import Var, initializer
 from spox._exceptions import BuildError
-from spox._future import initializer
 from spox._graph import arguments, results
 from spox._type_system import Sequence, Tensor
 


### PR DESCRIPTION
This change will expose the `initialiser` primitive to go along with `argument`. This change provides a more complete coverage of the `onnx` standard and provides a way to optimise `op.const`-s in the graph to `initialiser`-s.

Comparing `op.const` vs `initializer`:
```python
a = argument(Tensor(np.int64, ('N',)))

c = a
for x in range(10000):
    c = op.mul(c, op.const(1))

model: onnx.ModelProto = build(inputs={'a': a}, outputs={'c': c})
onnx.save(model, "big1.onnx")
```  

```python
a = argument(Tensor(np.int64, ('N',)))

c = a
for x in range(10000):
    c = op.mul(c, initializer(1))

model: onnx.ModelProto = build(inputs={'a': a}, outputs={'c': c})
onnx.save(model, "big2.onnx")
```

File-sizes:
```
-rw-r--r--   1 staff  1363443 Jan 20 21:47 big1.onnx
-rw-r--r--   1 staff   934553 Jan 20 21:46 big2.onnx
```

# Checklist
- Added a `CHANGELOG.rst` entry
