### PR TITLE
Imporve ONNX 1.14 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.10.1 (2023-02-07)
+-------------------
+
+**Other changes**
+
+- Spox's compatibility with older versions of onnx has been improved.
+
+
 0.10.0 (2023-02-02)
 -------------------
 

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -210,9 +210,16 @@ class _AttrIterable(Attr[Tuple[S, ...]], ABC):
         return cls(tuple(value), name) if value is not None else None
 
     def _to_onnx_deref(self) -> AttributeProto:
-        return make_attribute(
-            self._name, self.value, attr_type=self._attribute_proto_type
-        )
+        # the attr_type argument was only added in onnx>=1.15. It is a
+        # performance optimization for which we don't want to
+        # introduce a version bound. If we fail, we try again without
+        # it.
+        try:
+            return make_attribute(
+                self._name, self.value, attr_type=self._attribute_proto_type
+            )
+        except TypeError:
+            return make_attribute(self._name, self.value)
 
 
 class AttrFloat32s(_AttrIterable[float]):

--- a/src/spox/_attributes.py
+++ b/src/spox/_attributes.py
@@ -4,6 +4,7 @@ from typing import Any, Generic, Iterable, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
+import onnx
 from onnx import AttributeProto
 from onnx.helper import (
     make_attribute,
@@ -11,6 +12,7 @@ from onnx.helper import (
     make_sequence_type_proto,
     make_tensor_type_proto,
 )
+from packaging import version
 
 from spox import _type_system
 from spox._utils import dtype_to_tensor_type, from_array
@@ -210,15 +212,12 @@ class _AttrIterable(Attr[Tuple[S, ...]], ABC):
         return cls(tuple(value), name) if value is not None else None
 
     def _to_onnx_deref(self) -> AttributeProto:
-        # the attr_type argument was only added in onnx>=1.15. It is a
-        # performance optimization for which we don't want to
-        # introduce a version bound. If we fail, we try again without
-        # it.
-        try:
+        # 1.15 introduced attr_type which provides much better performance
+        if version.parse(onnx.__version__) >= version.parse("1.15"):
             return make_attribute(
                 self._name, self.value, attr_type=self._attribute_proto_type
             )
-        except TypeError:
+        else:
             return make_attribute(self._name, self.value)
 
 

--- a/tests/type_inference/test_scaler.py
+++ b/tests/type_inference/test_scaler.py
@@ -16,4 +16,4 @@ def test_scaler_inference():
 def test_scaler_inference_fails_mismatched_lengths():
     (x,) = arguments(x=Tensor(np.float64, ("N", 3)))
     with pytest.raises(InferenceError):
-        op_ml.scaler(x, offset=[0.0, 0.1], scale=[1])
+        op_ml.scaler(x, offset=[0.0, 0.1], scale=[1.0])


### PR DESCRIPTION
ONNX 1.15 introduced some performance optimizations which we are using since `0.10`. We can forego their usage if `onnx<1.15` without loss of functionality to avoid a version bound. 

Since Spox exports the ONNX standard which expands with each (minor) release, we can't claim full compatibility with older versions.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
