### PR TITLE
Add packaging dependency

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,6 +1,7 @@
 name: Build and upload to PyPI
 
 on:
+  push:
   pull_request:
   release:
     types:
@@ -23,6 +24,13 @@ jobs:
         run: |
           pip install build
           python -m build
+
+      - name: Test install and import
+        run: |
+          python -m venv ./env
+          . ./env/bin/activate
+          pip install dist/*.whl
+          python -c "import spox"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.10.2 (2023-02-08)
+-------------------
+
+**Other changes**
+
+- Added ``packaging`` as an explicit dependency.
+
+
 0.10.1 (2023-02-07)
 -------------------
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   # Runtime
   - numpy
   - onnx>=1.14.0
+  - packaging
   - python>=3.8
 
   # Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires-python = ">=3.8.0"
 dependencies = [
   "numpy",
   "onnx>=1.13",
+  "packaging",
 ]
 
 [project.urls]


### PR DESCRIPTION
This should have been added with #134 . The pypi package is currently broken if used in isolation. It pains me to pull in a new dependency, but it is a very light one (no secondary dependencies), it is the de facto standard, and I prefer this over hacking my own version string parsing. 

# Checklist

- [x] Added a `CHANGELOG.rst` entry
