### PR TITLE
Add open-source warning to issue and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,6 @@
+---
+name: New issue
+about: Create a new issue
+---
+
+<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->
+
 <!--
 Thank you for the pull request.
 Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.


### PR DESCRIPTION
I'm adding this to all open-source repos. See it in action: https://github.com/Quantco/multiregex/issues/new/choose