### PR TITLE
Improve performance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Change log
 
 **Other changes**
 
-- Improved performance
+- Improved node creation speed by skipping the storing of the traceback
 
 
 0.10.2 (2023-02-08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.10.3 (unreleased)
+-------------------
+
+**Other changes**
+
+- Improved performance
+
+
 0.10.2 (2023-02-08)
 -------------------
 

--- a/src/spox/_debug.py
+++ b/src/spox/_debug.py
@@ -1,8 +1,10 @@
 import sys
 from contextlib import contextmanager
 
-from spox._node import Node
 from spox._var import Var
+
+# If `STORE_TRACEBACK` is `True` any node created will store a traceback for its point of creation.
+STORE_TRACEBACK = False
 
 
 @contextmanager
@@ -14,6 +16,9 @@ def show_construction_tracebacks(debug_index):
     This context manager intercepts that error message and prints additional logs to the output with tracebacks
     of where the mentioned nodes where constructed.
     """
+    # Avoid circular dependency
+    from spox._node import Node
+
     try:
         yield
     except Exception as e:
@@ -35,6 +40,12 @@ def show_construction_tracebacks(debug_index):
             else:
                 assert isinstance(obj, Node)
                 node = obj
+
+            if node._traceback is None:
+                raise ValueError(
+                    "Set `spox._debug.STORE_TRACEBACK=True` before creating the ONNX model."
+                )
+
             print(f">>> from mentioned {name}\n", file=sys.stderr)
             print("".join(node._traceback[-6:-3]), file=sys.stderr)
             print(f"<<< where {name} was constructed\n", file=sys.stderr)

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -11,6 +11,7 @@ from typing import ClassVar, Dict, Iterable, List, Optional, Sequence, Set, Tupl
 import onnx
 
 from ._attributes import AttrGraph
+from ._debug import STORE_TRACEBACK
 from ._exceptions import InferenceWarning
 from ._fields import BaseAttributes, BaseInputs, BaseOutputs, VarFieldKind
 from ._type_system import Type
@@ -79,7 +80,7 @@ class Node(ABC):
     outputs: BaseOutputs
 
     out_variadic: Optional[int]
-    _traceback: List[str]
+    _traceback: Union[List[str], None]
 
     def __init__(
         self,
@@ -128,7 +129,10 @@ class Node(ABC):
             self.inference(infer_types, propagate_values)
         else:
             self.outputs = outputs
-        self._traceback = traceback.format_stack()
+
+        # Optionally store debug information about where this node was created
+        self._traceback = traceback.format_stack() if STORE_TRACEBACK else None
+
         # Performs type checking using known flags (like type_members)
         # and warns if type inference failed (some types are None).
         if validate:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,14 +5,14 @@ import numpy
 import onnxruntime
 import pytest
 
-from spox import _value_prop
-from spox._debug import show_construction_tracebacks
+from spox import _debug, _value_prop
 from spox._future import set_type_warning_level
 from spox._graph import Graph
 from spox._node import TypeWarningLevel
 
 set_type_warning_level(TypeWarningLevel.CRITICAL)
 _value_prop.VALUE_PROP_STRICT_CHECK = True
+_debug.STORE_TRACEBACK = True
 
 
 class ONNXRuntimeHelper:
@@ -37,12 +37,12 @@ class ONNXRuntimeHelper:
                 self._build_cache[graph] = model_bytes
             else:
                 model_bytes = self._build_cache[graph]
-            with show_construction_tracebacks(debug_index):
+            with _debug.show_construction_tracebacks(debug_index):
                 session = onnxruntime.InferenceSession(model_bytes)
         self._last_graph = graph
         self._last_session = session
         assert isinstance(session, onnxruntime.InferenceSession)
-        with show_construction_tracebacks(debug_index):
+        with _debug.show_construction_tracebacks(debug_index):
             result = {
                 output.name: result
                 for output, result in zip(


### PR DESCRIPTION
We currently store a traceback for every node we create, but there is no public way to expose that information. This PR foregoes the creation of the traceback based on a (private) global variable which may be set when needed. This change provides a considerable speedup for the default configuration.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
