### PR TITLE
Use ruff instead of black, isort, and flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,6 @@ jobs:
         run: |
           pip install .
           pip install pandoc
+          pre-commit install
           python tools/generate_opset.py
           git diff --exit-code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,9 @@
 repos:
-  - repo: https://github.com/Quantco/pre-commit-mirrors-black
-    rev: 23.12.1
+  - repo: https://github.com/Quantco/pre-commit-mirrors-ruff
+    rev: 0.2.2
     hooks:
-      - id: black-conda
-        args:
-          - --safe
-          - --target-version=py38
-  - repo: https://github.com/Quantco/pre-commit-mirrors-flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8-conda
-  - repo: https://github.com/Quantco/pre-commit-mirrors-isort
-    rev: 5.13.2
-    hooks:
-      - id: isort-conda
-        additional_dependencies: [-c, conda-forge, toml=0.10.2]
+      - id: ruff-conda
+      - id: ruff-format-conda
   - repo: https://github.com/Quantco/pre-commit-mirrors-mypy
     rev: "1.8.0"
     hooks:
@@ -27,7 +16,7 @@ repos:
         args:
           - --py38
   - repo: https://github.com/Quantco/pre-commit-mirrors-prettier
-    rev: 3.1.1
+    rev: 3.2.4
     hooks:
       - id: prettier-conda
         files: "\\.md$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,27 +57,12 @@ package-dir = {"" = "src"}
 where = ["src"]
 namespaces = false
 
-[tool.black]
-target-version = ['py38']
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.venv
-  | build
-  | dist
-)/
-'''
+[tool.ruff.lint]
+# Enable the isort rules.
+extend-select = ["I"]
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-ensure_newline_before_comments = true
-line_length = 88
-known_first_party = "spox"
-skip_glob = '\.eggs/*,\.git/*,\.venv/*,build/*,dist/*'
-default_section = 'THIRDPARTY'
+[tool.ruff.lint.isort]
+known-first-party = ["spox"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/src/spox/_standard.py
+++ b/src/spox/_standard.py
@@ -174,9 +174,9 @@ class StandardNode(Node):
         output_feed = run(model, input_feed)
 
         results = {
-            scope.var[str(name)]
-            ._which_output: unwrap_feed(scope.var[str(name)].unwrap_type(), result)
-            .value
+            scope.var[str(name)]._which_output: unwrap_feed(
+                scope.var[str(name)].unwrap_type(), result
+            ).value
             for name, result in output_feed.items()
         }
         return {k: v for k, v in results.items() if k is not None}

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -187,7 +187,7 @@ class Var:
 
 
 def result_type(
-    *types: Union[Var, numpy.generic, int, float]
+    *types: Union[Var, numpy.generic, int, float],
 ) -> typing.Type[numpy.generic]:
     """Promote type for all given element types/values using ``np.result_type``."""
     return numpy.dtype(

--- a/src/spox/opset/ai/onnx/ml/v3.py
+++ b/src/spox/opset/ai/onnx/ml/v3.py
@@ -1,44 +1,29 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
 from dataclasses import dataclass
-from typing import (  # noqa: F401
-    Any,
-    Callable,
+from typing import (
     Dict,
     Iterable,
-    List,
     Optional,
     Sequence,
     Tuple,
-    Union,
 )
-from typing import cast as typing_cast  # noqa: F401
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
 
 from spox._attributes import (
-    AttrDtype,
     AttrFloat32,
     AttrFloat32s,
-    AttrGraph,
     AttrInt64,
     AttrInt64s,
     AttrString,
     AttrStrings,
     AttrTensor,
-    AttrType,
 )
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Sequence as SpoxSequence  # noqa: F401
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._node import OpType
+from spox._standard import InferenceError, StandardNode
 from spox._type_system import Tensor, Type
-from spox._value_prop import PropValueType  # noqa: F401
-from spox._var import Var, result_type  # noqa: F401
+from spox._var import Var
 
 
 class _ArrayFeatureExtractor(StandardNode):

--- a/src/spox/opset/ai/onnx/ml/v4.py
+++ b/src/spox/opset/ai/onnx/ml/v4.py
@@ -1,44 +1,25 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
 from dataclasses import dataclass
-from typing import (  # noqa: F401
-    Any,
-    Callable,
-    Dict,
+from typing import (
     Iterable,
-    List,
     Optional,
-    Sequence,
-    Tuple,
-    Union,
 )
-from typing import cast as typing_cast  # noqa: F401
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
 
 from spox._attributes import (
-    AttrDtype,
     AttrFloat32,
     AttrFloat32s,
-    AttrGraph,
     AttrInt64,
     AttrInt64s,
     AttrString,
     AttrStrings,
     AttrTensor,
-    AttrType,
 )
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Sequence as SpoxSequence  # noqa: F401
-from spox._type_system import Tensor, Type
-from spox._value_prop import PropValueType  # noqa: F401
-from spox._var import Var, result_type  # noqa: F401
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._node import OpType
+from spox._standard import StandardNode
+from spox._var import Var
 from spox.opset.ai.onnx.ml.v3 import (
     _ArrayFeatureExtractor,
     _Binarizer,

--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -1,9 +1,6 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
 from dataclasses import dataclass
-from typing import (  # noqa: F401
-    Any,
+from typing import (
     Callable,
     Dict,
     Iterable,
@@ -11,12 +8,11 @@ from typing import (  # noqa: F401
     Optional,
     Sequence,
     Tuple,
-    Union,
 )
-from typing import cast as typing_cast  # noqa: F401
+from typing import cast as typing_cast
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
+import numpy.typing as npt
 
 from spox._attributes import (
     AttrDtype,
@@ -30,15 +26,14 @@ from spox._attributes import (
     AttrTensor,
     AttrType,
 )
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Sequence as SpoxSequence  # noqa: F401
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._graph import Graph, subgraph
+from spox._node import OpType
+from spox._standard import InferenceError, StandardNode
+from spox._type_system import Sequence as SpoxSequence
 from spox._type_system import Tensor, Type
-from spox._value_prop import PropValueType  # noqa: F401
-from spox._var import Var, result_type  # noqa: F401
+from spox._value_prop import PropValueType
+from spox._var import Var
 
 
 class _Abs(StandardNode):

--- a/src/spox/opset/ai/onnx/v18.py
+++ b/src/spox/opset/ai/onnx/v18.py
@@ -1,44 +1,24 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
 from dataclasses import dataclass
-from typing import (  # noqa: F401
-    Any,
-    Callable,
-    Dict,
+from typing import (
     Iterable,
-    List,
     Optional,
     Sequence,
-    Tuple,
-    Union,
 )
-from typing import cast as typing_cast  # noqa: F401
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
+import numpy.typing as npt
 
 from spox._attributes import (
-    AttrDtype,
     AttrFloat32,
-    AttrFloat32s,
-    AttrGraph,
     AttrInt64,
     AttrInt64s,
     AttrString,
-    AttrStrings,
-    AttrTensor,
-    AttrType,
 )
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Sequence as SpoxSequence  # noqa: F401
-from spox._type_system import Tensor, Type
-from spox._value_prop import PropValueType  # noqa: F401
-from spox._var import Var, result_type  # noqa: F401
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._node import OpType
+from spox._standard import StandardNode
+from spox._var import Var
 from spox.opset.ai.onnx.v17 import (
     _DFT,
     _GRU,

--- a/src/spox/opset/ai/onnx/v19.py
+++ b/src/spox/opset/ai/onnx/v19.py
@@ -1,22 +1,17 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
 from dataclasses import dataclass
-from typing import (  # noqa: F401
-    Any,
+from typing import (
     Callable,
     Dict,
     Iterable,
     List,
     Optional,
     Sequence,
-    Tuple,
-    Union,
 )
-from typing import cast as typing_cast  # noqa: F401
+from typing import cast as typing_cast
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
+import numpy.typing as npt
 
 from spox._attributes import (
     AttrDtype,
@@ -28,17 +23,14 @@ from spox._attributes import (
     AttrString,
     AttrStrings,
     AttrTensor,
-    AttrType,
 )
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Sequence as SpoxSequence  # noqa: F401
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._graph import Graph, subgraph
+from spox._node import OpType
+from spox._standard import StandardNode
 from spox._type_system import Tensor, Type
-from spox._value_prop import PropValueType  # noqa: F401
-from spox._var import Var, result_type  # noqa: F401
+from spox._value_prop import PropValueType
+from spox._var import Var
 from spox.opset.ai.onnx.v18 import (
     _DFT,
     _GRU,

--- a/src/spox/opset/ai/onnx/v20.py
+++ b/src/spox/opset/ai/onnx/v20.py
@@ -1,44 +1,22 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
 from dataclasses import dataclass
-from typing import (  # noqa: F401
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
+from typing import (
     Optional,
-    Sequence,
     Tuple,
-    Union,
 )
-from typing import cast as typing_cast  # noqa: F401
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
+import numpy.typing as npt
 
 from spox._attributes import (
-    AttrDtype,
-    AttrFloat32,
-    AttrFloat32s,
-    AttrGraph,
     AttrInt64,
-    AttrInt64s,
     AttrString,
-    AttrStrings,
     AttrTensor,
-    AttrType,
 )
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Sequence as SpoxSequence  # noqa: F401
-from spox._type_system import Tensor, Type
-from spox._value_prop import PropValueType  # noqa: F401
-from spox._var import Var, result_type  # noqa: F401
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._node import OpType
+from spox._standard import StandardNode
+from spox._var import Var
 from spox.opset.ai.onnx.v19 import (
     _GRU,
     _LRN,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ class ONNXRuntimeHelper:
         debug_index = {
             **graph._get_build_result().scope.var.of_name,
             **graph._get_build_result().scope.node.of_name,
-        }  # type: ignore
+        }
         if self._last_graph is graph:
             print("[ONNXRuntimeHelper] Reusing previous session.", file=sys.stderr)
             session = self._last_session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,10 @@ class ONNXRuntimeHelper:
         self._last_session = None
 
     def run(self, graph: Graph, unwrap: Optional[str] = None, **kwargs):
-        debug_index = {**graph._get_build_result().scope.var.of_name, **graph._get_build_result().scope.node.of_name}  # type: ignore
+        debug_index = {
+            **graph._get_build_result().scope.var.of_name,
+            **graph._get_build_result().scope.node.of_name,
+        }  # type: ignore
         if self._last_graph is graph:
             print("[ONNXRuntimeHelper] Reusing previous session.", file=sys.stderr)
             session = self._last_session

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -43,8 +43,16 @@ def linear():
 
         def constructor(self, attrs: Dict[str, Attr], inputs: Inputs) -> Outputs:
             # FIXME: At some point, attribute references should be properly type-hinted.
-            a = op.constant(value_float=_Ref(attrs["slope_outer"], outer_name="slope_outer", name="value_float"))  # type: ignore
-            b = op.constant(value_float=_Ref(attrs["shift_outer"], outer_name="shift_outer", name="value_float"))  # type: ignore
+            a = op.constant(
+                value_float=_Ref(
+                    attrs["slope_outer"], outer_name="slope_outer", name="value_float"
+                )  # type: ignore
+            )
+            b = op.constant(
+                value_float=_Ref(
+                    attrs["shift_outer"], outer_name="shift_outer", name="value_float"
+                )  # type: ignore
+            )
             x = inputs.X
             return self.Outputs(op.add(op.mul(a, x), b))
 
@@ -143,7 +151,11 @@ def cubic(linear):
             b = op.add(
                 op.mul(
                     x,
-                    op.constant(value_float=_Ref(attrs["a1"], outer_name="a1", name="value_float")),  # type: ignore
+                    op.constant(
+                        value_float=_Ref(
+                            attrs["a1"], outer_name="a1", name="value_float"
+                        )  # type: ignore
+                    ),
                 ),
                 op.constant(
                     value_float=_Ref(attrs["a0"], outer_name="a0", name="value_float"),  # type: ignore

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -143,8 +143,9 @@ def larger_graph(lin_fun_proto):
 
 
 def test_larger(onnx_helper, larger_graph):
-    a, b = numpy.random.random(5).astype(numpy.float32), numpy.random.random(5).astype(
-        numpy.float32
+    a, b = (
+        numpy.random.random(5).astype(numpy.float32),
+        numpy.random.random(5).astype(numpy.float32),
     )
     onnx_helper.assert_close(
         onnx_helper.run(larger_graph, "final", first=a, second=b), (2 * (a + b) + b) / a

--- a/tools/templates/preamble.jinja2
+++ b/tools/templates/preamble.jinja2
@@ -1,8 +1,8 @@
-# flake8: noqa
-import typing  # noqa: F401
-import warnings  # noqa: F401
+# ruff: noqa: E741 -- Allow ambiguous variable name
+import typing
+import warnings
 from dataclasses import dataclass
-from typing import (  # noqa: F401
+from typing import (
     Any,
     Callable,
     Dict,
@@ -13,13 +13,13 @@ from typing import (  # noqa: F401
     Tuple,
     Union,
 )
-from typing import cast as typing_cast  # noqa: F401
+from typing import cast as typing_cast
 
-import numpy as np  # noqa: F401
-import numpy.typing as npt  # noqa: F401
+import numpy as np
+import numpy.typing as npt
 
-from spox._var import Var, result_type  # noqa: F401
-from spox._fields import BaseAttributes, BaseInputs, BaseOutputs  # noqa: F401
+from spox._var import Var, result_type
+from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
 from spox._attributes import (
     AttrDtype,
     AttrFloat32,
@@ -32,9 +32,9 @@ from spox._attributes import (
     AttrTensor,
     AttrType,
 )
-from spox._graph import Graph, subgraph  # noqa: F401
-from spox._internal_op import intro  # noqa: F401
-from spox._node import OpType  # noqa: F401
-from spox._standard import InferenceError, StandardNode  # noqa: F401
-from spox._type_system import Tensor, Type, Sequence as SpoxSequence  # noqa: F401
-from spox._value_prop import PropValueType  # noqa: F401
+from spox._graph import Graph, subgraph
+from spox._internal_op import intro
+from spox._node import OpType
+from spox._standard import InferenceError, StandardNode
+from spox._type_system import Tensor, Type, Sequence as SpoxSequence
+from spox._value_prop import PropValueType


### PR DESCRIPTION
This PR replaces black, isort, and flake8 with ruff. Ruff does a great job removing unused imports in our opsets. There are some other minor formatting changes that I think are not worth the trouble of diverging from the default settings. 

Supersedes #133