### PR TITLE
Support shallow copy of Var objects and raise error on deepcopy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Change log
 **Other changes**
 
 - Improved node creation speed by skipping the storing of the traceback
-- :class:`spox.Var` objects may now be shallow copied
+- :class:`spox.Var` objects may now be shallow copied. Deep copies are explicitly prohibited.
 
 
 0.10.2 (2023-02-08)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change log
 **Other changes**
 
 - Improved node creation speed by skipping the storing of the traceback
+- :class:`spox.Var` objects may now be shallow copied
 
 
 0.10.2 (2023-02-08)

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -131,6 +131,14 @@ class Var:
         """Equivalent to ``self.unwrap_type().unwrap_optional()``."""
         return self.unwrap_type().unwrap_optional()
 
+    def __copy__(self) -> "Var":
+        # Simply return `self` to ensure that "copies" are still equal
+        # during the build process
+        return self
+
+    def __deepcopy__(self, _) -> "Var":
+        raise ValueError("'Var' objects cannot be deepcopied.")
+
     def __add__(self, other) -> "Var":
         return Var._operator_dispatcher.add(self, other)
 

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import numpy as np
 import onnx
 import onnxruntime
@@ -88,9 +90,13 @@ def test_simple_inline_bad_types(simple_model):
         inline(simple_model)(a, c)
 
 
-def test_copy_vars():
-    from copy import copy
-
+def test_shallow_copy_var():
     a = argument(Tensor(float, ()))
     b = op.add(a, copy(a))
     build({"a": a}, {"b": b})
+
+
+def test_shallow_deepcopy_var_raises():
+    a = argument(Tensor(float, ()))
+    with pytest.raises(ValueError):
+        deepcopy(a)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -86,3 +86,11 @@ def test_simple_inline_bad_types(simple_model):
         inline(simple_model)(b, a)
     with pytest.raises(TypeError):
         inline(simple_model)(a, c)
+
+
+def test_copy_vars():
+    from copy import copy
+
+    a = argument(Tensor(float, ()))
+    b = op.add(a, copy(a))
+    build({"a": a}, {"b": b})


### PR DESCRIPTION
Closes #139  by returning self for a shallow copy and raising an error for deep copies

# Checklist

- [x] Added a `CHANGELOG.rst` entry
