### PR TITLE
Bail node adaptation if node has subgraph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change log
 - Improved node creation speed by skipping the storing of the traceback
 - :class:`spox.Var` objects may now be shallow copied. Deep copies are explicitly prohibited.
 
+**Bug fix**
+
+- Addresses node adaptation failure when referencing a non-input name from inside a subgraph by aborting opset adaptation.
+
 
 0.10.2 (2023-02-08)
 -------------------

--- a/src/spox/_adapt.py
+++ b/src/spox/_adapt.py
@@ -5,6 +5,7 @@ import numpy
 import onnx
 import onnx.version_converter
 
+from ._attributes import AttrGraph
 from ._inline import _Inline
 from ._internal_op import _InternalNode
 from ._node import Node
@@ -107,6 +108,8 @@ def adapt_best_effort(
             node_names[node],
         )
     if isinstance(node, _InternalNode) or len(protos) != 1:
+        return None
+    if any(isinstance(attr, AttrGraph) for attr in node.attrs.get_fields().values()):
         return None
     proto: onnx.NodeProto
     (proto,) = protos


### PR DESCRIPTION
We should avoid node adaptation when the node in question has a subgraph (until we have a proper implementation that addresses issues like https://github.com/Quantco/spox/issues/145). This would affect the "If", "Loop", "Scan" and "SequenceMap" nodes. 

Note that previously, this would succeed if the subgraph did not reference anything outside of it. Is it worth making this check more complex/fine-grained and allow these to continue to succeed?

# Checklist

- [x] Added a `CHANGELOG.rst` entry
