### PR TITLE
Add option to drop unused inputs during build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.12.0 (2024-05-16)
+-------------------
+
+**New feature**
+
+- The :func:`spox.build` function gained the ``drop_unused_inputs`` argument.
+
+
 0.11.0 (2024-04-23)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,7 @@ check_untyped_defs = true
 [tool.pytest.ini_options]
 # This will be pytest's future default.
 addopts = "--import-mode=importlib"
+filterwarnings = [
+    # Protobuf warning seen when running the test suite
+    "ignore:.*Type google.protobuf.pyext.*:DeprecationWarning:.*",
+]

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -130,10 +130,7 @@ def build(
         model_proto = graph.to_onnx_model()
 
     # Validate that no further inputs were required.
-    unspecified_inputs = [
-        inp.name for inp in model_proto.graph.input if inp.name not in inputs
-    ]
-    if unspecified_inputs:
+    if any(inp.name not in inputs for inp in model_proto.graph.input):
         raise KeyError("Model requires additional inputs not provided in 'inputs'.")
 
     return model_proto

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -100,3 +100,22 @@ def test_shallow_deepcopy_var_raises():
     a = argument(Tensor(float, ()))
     with pytest.raises(ValueError):
         deepcopy(a)
+
+
+def test_build_drop_unused_arguments():
+    a = argument(Tensor(float, ()))
+    unused = argument(Tensor(float, ()))
+    c = op.add(a, a)
+    model_proto = build({"a": a, "unused": unused}, {"c": c}, drop_unused_inputs=True)
+    actual_inputs = [el.name for el in model_proto.graph.input]
+
+    assert actual_inputs == ["a"]
+
+
+@pytest.mark.parametrize("drop_unused", [True, False])
+def test_raise_missing_input(drop_unused):
+    a = argument(Tensor(float, ()))
+    b = argument(Tensor(float, ()))
+
+    with pytest.raises(KeyError):
+        build({"a": a}, {"c": op.add(a, b)}, drop_unused_inputs=drop_unused)


### PR DESCRIPTION
We removed this option back in the days under the assumption that it will be easy to add once needed - that time has come! 

# Checklist

- [x] Added a `CHANGELOG.rst` entry
