### PR TITLE
Add test for node adaptation on Squeeze11

### DIFF
--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -239,8 +239,8 @@ def test_inline_model_custom_node_nested(old_squeeze: onnx.ModelProto):
 
 
 def test_if_adapatation_squeeze():
-    cond = argument(Tensor(numpy.bool_, ()))
-    b = argument(Tensor(numpy.float32, (1,)))
+    cond = argument(Tensor(np.bool_, ()))
+    b = argument(Tensor(np.float32, (1,)))
     squeezed = squeeze11(b, [0])
     out = op18.if_(
         cond,
@@ -250,16 +250,16 @@ def test_if_adapatation_squeeze():
     model = build({"b": b, "cond": cond}, {"out": out[0]})
 
     # predict on model
-    b = numpy.array([1.1], dtype=numpy.float32)
-    cond = numpy.array(True, dtype=numpy.bool_)
+    b = np.array([1.1], dtype=np.float32)
+    cond = np.array(True, dtype=np.bool_)
     out = ort.InferenceSession(model.SerializeToString()).run(
         None, {"b": b, "cond": cond}
     )
 
 
 def test_if_adaptation_const():
-    sq = op19.const(1.1453, dtype=numpy.float32)
-    b = argument(Tensor(numpy.float32, ("N",)))
+    sq = op19.const(1.1453, dtype=np.float32)
+    b = argument(Tensor(np.float32, ("N",)))
     cond = op18.equal(sq, b)
     out = op18.if_(cond, then_branch=lambda: [sq], else_branch=lambda: [sq])
     model = build({"b": b}, {"out": out[0]})

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -91,14 +91,14 @@ class Squeeze11(StandardNode):
     inputs: Inputs
     outputs: Outputs
 
-
-@pytest.fixture
-def old_squeeze_graph(old_squeeze):
     def squeeze11(_data: Var, _axes: Iterable[int]):
         return Squeeze11(
             Squeeze11.Attributes(AttrInt64s(_axes, "axes")), Squeeze11.Inputs(_data)
         ).outputs.squeezed
 
+
+@pytest.fixture
+def old_squeeze_graph(old_squeeze):
     (data,) = arguments(
         data=Tensor(
             numpy.float32,
@@ -108,7 +108,7 @@ def old_squeeze_graph(old_squeeze):
             ),
         )
     )
-    result = squeeze11(data, [0])
+    result = Squeeze11.squeeze11(data, [0])
     return results(final=result).with_opset(("ai.onnx", 17))
 
 

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -91,7 +91,6 @@ class Squeeze11(StandardNode):
     inputs: Inputs
     outputs: Outputs
 
-    @classmethod
     def squeeze11(cls, _data: Var, _axes: Iterable[int]):
         return Squeeze11(
             Squeeze11.Attributes(AttrInt64s(_axes, "axes")), Squeeze11.Inputs(_data)

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -262,4 +262,5 @@ def test_if_adaptation_const():
     b = argument(Tensor(numpy.float32, ("N",)))
     cond = op18.equal(sq, b)
     out = op18.if_(cond, then_branch=lambda: [sq], else_branch=lambda: [sq])
-    build({"b": b}, {"out": out[0]})
+    model = build({"b": b}, {"out": out[0]})
+    assert model.domain == "" or model.domain == "ai.onnx"

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -91,10 +91,11 @@ class Squeeze11(StandardNode):
     inputs: Inputs
     outputs: Outputs
 
-    def squeeze11(self, _data: Var, _axes: Iterable[int]):
-        return Squeeze11(
-            Squeeze11.Attributes(AttrInt64s(_axes, "axes")), Squeeze11.Inputs(_data)
-        ).outputs.squeezed
+
+def squeeze11(_data: Var, _axes: Iterable[int]):
+    return Squeeze11(
+        Squeeze11.Attributes(AttrInt64s(_axes, "axes")), Squeeze11.Inputs(_data)
+    ).outputs.squeezed
 
 
 @pytest.fixture
@@ -108,7 +109,7 @@ def old_squeeze_graph(old_squeeze):
             ),
         )
     )
-    result = Squeeze11.squeeze11(data, [0])
+    result = squeeze11(data, [0])
     return results(final=result).with_opset(("ai.onnx", 17))
 
 
@@ -240,11 +241,11 @@ def test_inline_model_custom_node_nested(old_squeeze: onnx.ModelProto):
 def test_if_adapatation_squeeze():
     cond = argument(Tensor(numpy.bool_, ()))
     b = argument(Tensor(numpy.float32, (1,)))
-    squeezed = Squeeze11.squeeze11(b, [0])
+    squeezed = squeeze11(b, [0])
     out = op18.if_(
         cond,
         then_branch=lambda: [squeezed],
-        else_branch=lambda: [Squeeze11.squeeze11(b, [0])],
+        else_branch=lambda: [squeeze11(b, [0])],
     )
     model = build({"b": b, "cond": cond}, {"out": out[0]})
 

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -91,7 +91,7 @@ class Squeeze11(StandardNode):
     inputs: Inputs
     outputs: Outputs
 
-    def squeeze11(cls, _data: Var, _axes: Iterable[int]):
+    def squeeze11(self, _data: Var, _axes: Iterable[int]):
         return Squeeze11(
             Squeeze11.Attributes(AttrInt64s(_axes, "axes")), Squeeze11.Inputs(_data)
         ).outputs.squeezed

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -238,7 +238,7 @@ def test_inline_model_custom_node_nested(old_squeeze: onnx.ModelProto):
     build({"a": a}, {"c": c})
 
 
-def test_if_adaptation_const():
+def test_if_adapatation_squeeze():
     cond = argument(Tensor(numpy.bool_, ()))
     b = argument(Tensor(numpy.float32, (1,)))
     squeezed = Squeeze11.squeeze11(b, [0])
@@ -255,3 +255,11 @@ def test_if_adaptation_const():
     out = ort.InferenceSession(model.SerializeToString()).run(
         None, {"b": b, "cond": cond}
     )
+
+
+def test_if_adaptation_const():
+    sq = op19.const(1.1453, dtype=numpy.float32)
+    b = argument(Tensor(numpy.float32, ("N",)))
+    cond = op18.equal(sq, b)
+    out = op18.if_(cond, then_branch=lambda: [sq], else_branch=lambda: [sq])
+    build({"b": b}, {"out": out[0]})

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -91,7 +91,8 @@ class Squeeze11(StandardNode):
     inputs: Inputs
     outputs: Outputs
 
-    def squeeze11(_data: Var, _axes: Iterable[int]):
+    @classmethod
+    def squeeze11(cls, _data: Var, _axes: Iterable[int]):
         return Squeeze11(
             Squeeze11.Attributes(AttrInt64s(_axes, "axes")), Squeeze11.Inputs(_data)
         ).outputs.squeezed

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -264,3 +264,7 @@ def test_if_adaptation_const():
     out = op18.if_(cond, then_branch=lambda: [sq], else_branch=lambda: [sq])
     model = build({"b": b}, {"out": out[0]})
     assert model.domain == "" or model.domain == "ai.onnx"
+    assert (
+        model.opset_import[0].domain == "ai.onnx" or model.opset_import[0].domain == ""
+    )
+    assert model.opset_import[0].version > 11


### PR DESCRIPTION
This test shows that simple subgraph adaptation works

In contrast to #145 

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for the pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

# Checklist

- [x] ~~Added a `CHANGELOG.rst` entry~~
Note: No changes, which necessitate an addition to the changelog
