### PR TITLE
keep the empty params remain empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,13 @@
 Change log
 ==========
 
-0.12.1 (unreleased)
+0.12.1 (2024-06-18)
 -------------------
+
+**Bug fix**
+
+- Unset optional inputs are no longer erroneously prefixed by :func:`~spox.inline`.
+
 
 **Other changes**
 

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -154,6 +154,8 @@ class _Inline(_InternalNode):
         inner_node_renames: Dict[str, str] = {}
 
         def reserve_prefixed(name: str) -> str:
+            if not name:
+                return name
             return scope.var.reserve(
                 scope.var.maybe_enum(f"{scope.node[self]}__{name}")
             )


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for the pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

There are some operators that have optional parameters, just like Pad, which has the optional parameter constant_value, and like Resize, which has the optional parameters roi and scales.

It will edit empty parameters when there are empty parameters in the subgraph.

Therefore, I have fixed the bug.
