### PR TITLE
Fix strict value prop strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.12.2 (unreleased)
+-------------------
+
+**Bug fix**
+
+- Value propagation of string tensors no longer raises an erroneous ``ValueError`` in some instances.
+
+
 0.12.1 (2024-06-18)
 -------------------
 

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -75,11 +75,15 @@ class PropValue:
 
     def check(self) -> bool:
         if isinstance(self.type, Tensor):
-            return (
+            if not (
                 isinstance(self.value, np.ndarray)
-                and self.value.dtype.type is self.type.dtype.type
                 and Shape.from_simple(self.value.shape) <= self.type._shape
-            )
+            ):
+                return False
+            # Strings need some special handling
+            if self.value.dtype == object and self.type.dtype == str:
+                return True
+            return self.value.dtype.type is self.type.dtype.type
         elif isinstance(self.type, Sequence):
             return isinstance(self.value, list) and all(
                 elem.type._subtype(self.type.elem_type) for elem in self.value

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -5,7 +5,7 @@ import pytest
 import spox
 import spox._future
 import spox.opset.ai.onnx.ml.v3 as ml
-import spox.opset.ai.onnx.v17 as op
+import spox.opset.ai.onnx.v20 as op
 from spox import Var, _type_system
 from spox._graph import arguments, results
 from spox._shape import Shape
@@ -205,3 +205,11 @@ def test_value_propagation_does_not_fail_on_unseen_opsets(value_prop_backend):
     )
 
     spox.inline(model)(X=op.const(["Test Test"], dtype=np.str_))
+
+
+def test_strings(value_prop_backend):
+    x, y = op.const("foo"), op.const("bar")
+    assert op.string_concat(x, y)._value.value == "foobar"  # type: ignore
+
+    x, y = op.const(["foo"]), op.const(["bar"])
+    np.testing.assert_equal(op.string_concat(x, y)._value.value, np.array(["foobar"]))  # type: ignore


### PR DESCRIPTION
The value propagation raised a `ValueError` for string tensors if `VALUE_PROP_STRICT_CHECK` was `True`.  

# Checklist

- [x] Added a `CHANGELOG.rst` entry
