### PR TITLE
Use `import numpy as np` throughout

### DIFF
--- a/src/spox/_adapt.py
+++ b/src/spox/_adapt.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Dict, List, Optional
 
-import numpy
+import numpy as np
 import onnx
 import onnx.version_converter
 
@@ -43,7 +43,7 @@ def adapt_node(
         initializers = [
             from_array(var._value, name)
             for name, var in node.inputs.get_vars().items()
-            if isinstance(var._value, numpy.ndarray)
+            if isinstance(var._value, np.ndarray)
         ]
     except ValueError:
         return None

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -13,7 +13,7 @@ from typing import (
     TypeVar,
 )
 
-import numpy
+import numpy as np
 import onnx
 
 from . import _function
@@ -63,7 +63,7 @@ class BuildResult:
     results: Tuple[Var, ...]
     opset_req: Set[Tuple[str, int]]
     functions: Tuple["_function.Function", ...]
-    initializers: Dict[Var, numpy.ndarray]
+    initializers: Dict[Var, np.ndarray]
 
 
 class Builder:
@@ -433,7 +433,7 @@ class Builder:
         # A bunch of model metadata we're collecting
         opset_req: Set[Tuple[str, int]] = set()
         functions: List[_function.Function] = []
-        initializers: Dict[Var, numpy.ndarray] = {}
+        initializers: Dict[Var, np.ndarray] = {}
 
         # Add arguments to our scope
         for arg in self.arguments_of[graph]:

--- a/src/spox/_graph.py
+++ b/src/spox/_graph.py
@@ -5,7 +5,7 @@ import itertools
 from dataclasses import dataclass, replace
 from typing import Callable, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 
-import numpy
+import numpy as np
 import onnx
 import onnx.shape_inference
 
@@ -21,7 +21,7 @@ from ._utils import from_array
 from ._var import Var
 
 
-def arguments_dict(**kwargs: Optional[Union[Type, numpy.ndarray]]) -> Dict[str, Var]:
+def arguments_dict(**kwargs: Optional[Union[Type, np.ndarray]]) -> Dict[str, Var]:
     """
     Parameters
     ----------
@@ -47,7 +47,7 @@ def arguments_dict(**kwargs: Optional[Union[Type, numpy.ndarray]]) -> Dict[str, 
                 ),
                 BaseInputs(),
             ).outputs.arg
-        elif isinstance(info, numpy.ndarray):
+        elif isinstance(info, np.ndarray):
             ty = Tensor(info.dtype, info.shape)
             result[name] = Argument(
                 Argument.Attributes(
@@ -62,13 +62,13 @@ def arguments_dict(**kwargs: Optional[Union[Type, numpy.ndarray]]) -> Dict[str, 
     return result
 
 
-def arguments(**kwargs: Optional[Union[Type, numpy.ndarray]]) -> Tuple[Var, ...]:
+def arguments(**kwargs: Optional[Union[Type, np.ndarray]]) -> Tuple[Var, ...]:
     """This function is a shorthand for a respective call to ``arguments_dict``, unpacking the Vars from the dict."""
     return tuple(arguments_dict(**kwargs).values())
 
 
 def enum_arguments(
-    *infos: Union[Type, numpy.ndarray], prefix: str = "in"
+    *infos: Union[Type, np.ndarray], prefix: str = "in"
 ) -> Tuple[Var, ...]:
     """
     Convenience function for creating an enumeration of arguments, prefixed with ``prefix``.
@@ -91,7 +91,7 @@ def enum_arguments(
     return arguments(**{f"{prefix}{i}": info for i, info in enumerate(infos)})
 
 
-def initializer(arr: numpy.ndarray) -> Var:
+def initializer(arr: np.ndarray) -> Var:
     """
     Create a single initializer (frozen argument) with a given array value.
 
@@ -260,7 +260,7 @@ class Graph:
             self._extra_opset_req if self._extra_opset_req is not None else set()
         )
 
-    def _get_initializers_by_name(self) -> Dict[str, numpy.ndarray]:
+    def _get_initializers_by_name(self) -> Dict[str, np.ndarray]:
         """Internal function for accessing the initializers by name in the build."""
         return {
             self._get_build_result().scope.var[var]: init

--- a/src/spox/_standard.py
+++ b/src/spox/_standard.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, Callable, Dict, Tuple
 
-import numpy
+import numpy as np
 import onnx
 import onnx.reference
 import onnx.shape_inference
@@ -99,7 +99,7 @@ class StandardNode(Node):
         initializers = [
             from_array(var._value.value, key)
             for key, var in self.inputs.get_vars().items()
-            if var._value and isinstance(var._value.value, numpy.ndarray)
+            if var._value and isinstance(var._value.value, np.ndarray)
         ]
         #  Graph and model
         graph = onnx.helper.make_graph(

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -1,7 +1,7 @@
 import typing
 from typing import Any, Callable, ClassVar, Optional, TypeVar, Union
 
-import numpy
+import numpy as np
 
 from . import _type_system, _value_prop
 
@@ -195,11 +195,11 @@ class Var:
 
 
 def result_type(
-    *types: Union[Var, numpy.generic, int, float],
-) -> typing.Type[numpy.generic]:
+    *types: Union[Var, np.generic, int, float],
+) -> typing.Type[np.generic]:
     """Promote type for all given element types/values using ``np.result_type``."""
-    return numpy.dtype(
-        numpy.result_type(
+    return np.dtype(
+        np.result_type(
             *(
                 typ.unwrap_tensor().dtype if isinstance(typ, Var) else typ
                 for typ in types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Dict, Optional
 
-import numpy
+import numpy as np
 import onnxruntime
 import pytest
 
@@ -63,12 +63,12 @@ class ONNXRuntimeHelper:
         else:
             if isinstance(given, list):
                 for subarray in given:
-                    numpy.testing.assert_allclose(
-                        given, numpy.array(expected, dtype=subarray.dtype), rtol=rtol
+                    np.testing.assert_allclose(
+                        given, np.array(expected, dtype=subarray.dtype), rtol=rtol
                     )
             else:
-                numpy.testing.assert_allclose(
-                    given, numpy.array(expected, dtype=given.dtype), rtol=rtol
+                np.testing.assert_allclose(
+                    given, np.array(expected, dtype=given.dtype), rtol=rtol
                 )
 
 

--- a/tests/full/conftest.py
+++ b/tests/full/conftest.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-import numpy
+import numpy as np
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
@@ -16,17 +16,17 @@ class Extras:
 
     def false(self):
         if self._false is None:
-            self._false = op.const(numpy.array(False))
+            self._false = op.const(np.array(False))
         return self._false
 
     def true(self):
         if self._true is None:
-            self._true = op.const(numpy.array(True))
+            self._true = op.const(np.array(True))
         return self._true
 
     def empty_i64(self):
         if self._empty_i64 is None:
-            self._empty_i64 = op.const(numpy.array([], dtype=numpy.int64))
+            self._empty_i64 = op.const(np.array([], dtype=np.int64))
         return self._empty_i64
 
     @staticmethod
@@ -52,10 +52,10 @@ class Extras:
 
     @staticmethod
     def at(t: Var, j: Var) -> Var:
-        j = op.reshape(j, op.const(numpy.array([1], dtype=numpy.int64)))
+        j = op.reshape(j, op.const(np.array([1], dtype=np.int64)))
         return op.reshape(
             op.slice(t, j, op.add(j, op.const(1))),
-            op.const(numpy.array([], dtype=numpy.int64)),
+            op.const(np.array([], dtype=np.int64)),
         )
 
     @staticmethod
@@ -89,9 +89,9 @@ class Extras:
             op.reshape(op.size(xs), op.const([1])),
             None,
             [
-                op.sequence_empty(dtype=numpy.int64),
-                op.sequence_empty(dtype=numpy.int64),
-                op.const(numpy.array(True)),
+                op.sequence_empty(dtype=np.int64),
+                op.sequence_empty(dtype=np.int64),
+                op.const(np.array(True)),
             ],
             body=bracket_matcher_step,
         )
@@ -104,13 +104,13 @@ class Extras:
         return op.pad(op.const([1]), ext.scalars(i, op.sub(op.sub(n, i), op.const(1))))
 
     def set_to(ext, t: Var, j: Var, x: Var) -> Var:
-        return op.where(op.cast(ext.onehot(op.size(t), j), to=numpy.bool_), x, t)
+        return op.where(op.cast(ext.onehot(op.size(t), j), to=np.bool_), x, t)
 
     @staticmethod
     def is_token(var: Var, token: str) -> Var:
         return op.equal(
-            op.cast(var, to=numpy.int32),
-            op.cast(op.const(numpy.uint8(ord(token))), to=numpy.int32),
+            op.cast(var, to=np.int32),
+            op.cast(op.const(np.uint8(ord(token))), to=np.int32),
         )
 
     def flat_concat(ext, s: Var) -> Var:

--- a/tests/future/test_var_operators.py
+++ b/tests/future/test_var_operators.py
@@ -1,6 +1,5 @@
 import operator
 
-import numpy
 import numpy as np
 import pytest
 
@@ -125,4 +124,4 @@ def test_var_operator_promotion_like_numpy(bin_op, lhs, rhs):
         assert (
             spox_value.dtype == numpy_value.dtype
         ), f"{lhs!r}: {type(lhs)} | {rhs!r}: {type(rhs)}"
-        assert numpy.isclose(spox_value, numpy_value).all()
+        assert np.isclose(spox_value, numpy_value).all()

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Iterable
 
-import numpy
+import numpy as np
 import onnx
 import onnx.parser
 import pytest
@@ -52,7 +52,7 @@ agraph (float[N] A) => (float[N] B)
 def inline_old_squeeze_graph(old_squeeze):
     (data,) = arguments(
         data=Tensor(
-            numpy.float32,
+            np.float32,
             (
                 1,
                 None,
@@ -65,7 +65,7 @@ def inline_old_squeeze_graph(old_squeeze):
 
 @pytest.fixture
 def inline_old_identity_twice_graph(old_identity):
-    (x,) = arguments(data=Tensor(numpy.float32, (None,)))
+    (x,) = arguments(data=Tensor(np.float32, (None,)))
     (y,) = inline(old_identity)(A=x).values()
     (z,) = inline(old_identity)(A=y).values()
     return results(final=z).with_opset(("ai.onnx", 17))
@@ -99,7 +99,7 @@ def old_squeeze_graph(old_squeeze):
 
     (data,) = arguments(
         data=Tensor(
-            numpy.float32,
+            np.float32,
             (
                 1,
                 None,
@@ -115,7 +115,7 @@ def test_adapts_inline_old_squeeze(onnx_helper, inline_old_squeeze_graph):
         onnx_helper.run(
             inline_old_squeeze_graph,
             "final",
-            data=numpy.array([[1, 2, 3, 4]], dtype=numpy.float32),
+            data=np.array([[1, 2, 3, 4]], dtype=np.float32),
         ),
         [1, 2, 3, 4],
     )
@@ -126,7 +126,7 @@ def test_adapts_inline_old_identity_twice(onnx_helper, inline_old_identity_twice
         onnx_helper.run(
             inline_old_identity_twice_graph,
             "final",
-            data=numpy.array([1, 2, 3, 4], dtype=numpy.float32),
+            data=np.array([1, 2, 3, 4], dtype=np.float32),
         ),
         [1, 2, 3, 4],
     )
@@ -137,14 +137,14 @@ def test_adapts_singleton_old_squeeze(onnx_helper, old_squeeze_graph):
         onnx_helper.run(
             old_squeeze_graph,
             "final",
-            data=numpy.array([[1, 2, 3, 4]], dtype=numpy.float32),
+            data=np.array([[1, 2, 3, 4]], dtype=np.float32),
         ),
         [1, 2, 3, 4],
     )
 
 
 def test_adapt_node_with_repeating_input_names():
-    a = argument(Tensor(numpy.float32, ("N",)))
+    a = argument(Tensor(np.float32, ("N",)))
     b = op18.equal(a, a)
     c = op19.identity(a)
 
@@ -182,7 +182,7 @@ def test_inline_model_custom_node_only():
     # Ensure that our model is valid
     onnx.checker.check_model(model, full_check=True)
 
-    (a,) = arguments(data=Tensor(numpy.str_, ("N",)))
+    (a,) = arguments(data=Tensor(np.str_, ("N",)))
     (b,) = inline(model)(a).values()
 
     # Add another node to the model to trigger the adaption logic
@@ -227,7 +227,7 @@ def test_inline_model_custom_node_nested(old_squeeze: onnx.ModelProto):
     # Ensure that our model is valid
     onnx.checker.check_model(model, full_check=True)
 
-    (a,) = arguments(data=Tensor(numpy.float32, ("N",)))
+    (a,) = arguments(data=Tensor(np.float32, ("N",)))
     (b,) = inline(model)(a).values()
 
     # Add another node to the model to trigger the adaption logic

--- a/tests/test_constructors.py
+++ b/tests/test_constructors.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 
 import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments, results
@@ -6,22 +6,22 @@ from spox._type_system import Tensor
 
 
 def test_explicit_unspecified_optional(onnx_helper):
-    (x,) = arguments(x=Tensor(numpy.float32, (None,)))
+    (x,) = arguments(x=Tensor(np.float32, (None,)))
     r = op.clip(x, min=None, max=op.constant(value_float=0.0))
     graph = results(r=r)
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "r", x=numpy.array([-1, 1, 2], numpy.float32)),
+        onnx_helper.run(graph, "r", x=np.array([-1, 1, 2], np.float32)),
         [-1, 0, 0],
     )
 
 
 def test_unspecified_optional(onnx_helper):
-    (x,) = arguments(x=Tensor(numpy.float32, (None,)))
+    (x,) = arguments(x=Tensor(np.float32, (None,)))
     r = op.clip(x, max=op.constant(value_float=1.0))
     r = op.clip(r, min=op.constant(value_float=-1.0))
     graph = results(r=r)
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "r", x=numpy.array([-3, -1, 1, 2], numpy.float32)),
+        onnx_helper.run(graph, "r", x=np.array([-3, -1, 1, 2], np.float32)),
         [-1, -1, 1, 1],
     )
 
@@ -35,7 +35,7 @@ def test_variadic_no_input_list_mutation(onnx_helper):
 
 
 def test_variadic_no_attr_mutation_array(onnx_helper):
-    a = numpy.array([1])
+    a = np.array([1])
     x = op.constant(value=a)
     a[0] = 0
     assert isinstance(x._op, op._Constant)

--- a/tests/test_equiv_types.py
+++ b/tests/test_equiv_types.py
@@ -1,6 +1,6 @@
 from typing import List
 
-import numpy
+import numpy as np
 import pytest
 
 from spox._shape import Shape
@@ -20,7 +20,7 @@ def shape_clique(request) -> List[Shape]:
 
 @pytest.fixture(
     params=[
-        [Tensor(numpy.int32, (2, 3, 4)), Tensor(numpy.int32, None), Type()],
+        [Tensor(np.int32, (2, 3, 4)), Tensor(np.int32, None), Type()],
     ]
 )
 def weak_type_clique(request) -> List[Type]:
@@ -51,7 +51,7 @@ def test_incompatible_shapes(first, second):
 
 @pytest.mark.parametrize(
     "first,second",
-    [(Tensor(numpy.int32, (2, 3)), Tensor(numpy.int64, (2, 3)))],
+    [(Tensor(np.int32, (2, 3)), Tensor(np.int64, (2, 3)))],
 )
 def test_incompatible_types(first, second):
     assert not (first._subtype(second) or second._subtype(first))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
@@ -10,21 +10,21 @@ from spox._type_system import Tensor
 @pytest.fixture
 def min_graph():
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float32, (None,))
     )
     return results(final=op.add(first, second))
 
 
 @pytest.fixture
 def square_graph():
-    (value,) = arguments(value=Tensor(numpy.float32, (None,)))
+    (value,) = arguments(value=Tensor(np.float32, (None,)))
     return results(final=op.identity(op.mul(value, value)))
 
 
 @pytest.fixture
 def trivial_seq_graph():
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float32, (None,))
     )
     return results(final=intro(op.add(first, second), second))
 
@@ -32,7 +32,7 @@ def trivial_seq_graph():
 @pytest.fixture
 def expanding_seq_graph():
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float32, (None,))
     )
     return results(final=intro(first, second, op.add(first, second)))
 
@@ -40,7 +40,7 @@ def expanding_seq_graph():
 @pytest.fixture
 def copy_graph():
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float64, (None,))
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float64, (None,))
     )
     return results(final=first)
 
@@ -48,22 +48,20 @@ def copy_graph():
 @pytest.fixture
 def tri_graph():
     first, second, third = arguments(
-        first=Tensor(numpy.float32, (2, None)),
-        second=Tensor(numpy.float32, (None,)),
-        third=Tensor(numpy.int32, (None,)),
+        first=Tensor(np.float32, (2, None)),
+        second=Tensor(np.float32, (None,)),
+        third=Tensor(np.int32, (None,)),
     )
-    return results(
-        final=op.add(first, op.mul(second, op.cast(third, to=numpy.float32)))
-    )
+    return results(final=op.add(first, op.mul(second, op.cast(third, to=np.float32))))
 
 
 @pytest.fixture
 def initializer_graph():
     normal, defaulted = arguments(
-        normal=Tensor(numpy.float32, (None,)),
-        defaulted=numpy.array([3, 2, 1], dtype=numpy.float32),
+        normal=Tensor(np.float32, (None,)),
+        defaulted=np.array([3, 2, 1], dtype=np.float32),
     )
-    frozen = initializer(numpy.array([1, 10, 100], dtype=numpy.float32))
+    frozen = initializer(np.array([1, 10, 100], dtype=np.float32))
     return results(result=op.mul(op.add(normal, defaulted), frozen))
 
 
@@ -106,7 +104,7 @@ def test_expanding_seq(onnx_helper, expanding_seq_graph):
 
 def test_no_shape_throws():
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32)
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float32)
     )
     fun = results(final=op.add(first, second))
     with pytest.raises(ValueError):
@@ -115,7 +113,7 @@ def test_no_shape_throws():
 
 def test_no_type_throws():
     with pytest.raises(TypeError):
-        first, second = arguments(first=Tensor(numpy.float32, (None,)), second=None)
+        first, second = arguments(first=Tensor(np.float32, (None,)), second=None)
 
 
 def test_copy(onnx_helper, copy_graph):
@@ -128,12 +126,12 @@ def test_copy(onnx_helper, copy_graph):
 
 
 def test_triple_with_cast(onnx_helper, tri_graph):
-    a = numpy.random.rand(2, 4).astype(numpy.float32)
-    b = numpy.random.rand(4).astype(numpy.float32)
-    c = numpy.array([1, 2, 3, 4], dtype=numpy.int32)
+    a = np.random.rand(2, 4).astype(np.float32)
+    b = np.random.rand(4).astype(np.float32)
+    c = np.array([1, 2, 3, 4], dtype=np.int32)
     onnx_helper.assert_close(
         onnx_helper.run(tri_graph, "final", first=a, second=b, third=c),
-        a + b * c.astype(numpy.float32),
+        a + b * c.astype(np.float32),
     )
 
 

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -1,7 +1,7 @@
 import itertools
 from typing import Any, List
 
-import numpy
+import numpy as np
 import pytest
 
 from spox._future import initializer
@@ -9,16 +9,16 @@ from spox._future import initializer
 TESTED_INITIALIZER_ROWS: List[List[Any]] = [
     [0, 1, 2],
     [0.0, 1.0, 2.0],
-    [numpy.float16(3.14), numpy.float16(5.3)],
+    [np.float16(3.14), np.float16(5.3)],
     ["abc", "def"],
     [True, False],
 ]
 
 
 def assert_expected_initializer(var, value):
-    numpy.testing.assert_equal(var._get_value(), numpy.array(value))
-    assert var.unwrap_tensor().dtype.type == numpy.array(value).dtype.type
-    assert var.unwrap_tensor().shape == numpy.array(value).shape
+    np.testing.assert_equal(var._get_value(), np.array(value))
+    assert var.unwrap_tensor().dtype.type == np.array(value).dtype.type
+    assert var.unwrap_tensor().shape == np.array(value).shape
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-import numpy
+import numpy as np
 import onnx
 import onnx.parser
 import pytest
@@ -42,7 +42,7 @@ agraph (float[N] X) => (float[N] Y)
 }
 """
     )
-    model.graph.initializer.append(from_array(numpy.array(1, numpy.float32), "One"))
+    model.graph.initializer.append(from_array(np.array(1, np.float32), "One"))
     return model
 
 
@@ -53,8 +53,8 @@ def inc_proto_sparse_one(inc_proto) -> onnx.ModelProto:
     del model.graph.initializer[:]
     model.graph.sparse_initializer.append(
         onnx.helper.make_sparse_tensor(
-            from_array(numpy.array([1], numpy.float32), "One"),
-            from_array(numpy.array([0], numpy.int64), "OneI"),
+            from_array(np.array([1], np.float32), "One"),
+            from_array(np.array([0], np.int64), "OneI"),
             [1],
         )
     )
@@ -108,7 +108,7 @@ def relu_proto() -> onnx.ModelProto:
 @pytest.fixture
 def min_graph(lin_fun_proto):
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float32, (None,))
     )
     (result,) = inline(lin_fun_proto)(
         A=first, X=op.constant(value_float=1.0), B=second
@@ -132,7 +132,7 @@ def test_minimal(onnx_helper, min_graph):
 @pytest.fixture
 def larger_graph(lin_fun_proto):
     first, second = arguments(
-        first=Tensor(numpy.float32, (None,)), second=Tensor(numpy.float32, (None,))
+        first=Tensor(np.float32, (None,)), second=Tensor(np.float32, (None,))
     )
     (result,) = inline(lin_fun_proto)(
         A=op.add(first, second), X=op.constant(value_float=2.0), B=second
@@ -142,8 +142,8 @@ def larger_graph(lin_fun_proto):
 
 def test_larger(onnx_helper, larger_graph):
     a, b = (
-        numpy.random.random(5).astype(numpy.float32),
-        numpy.random.random(5).astype(numpy.float32),
+        np.random.random(5).astype(np.float32),
+        np.random.random(5).astype(np.float32),
     )
     onnx_helper.assert_close(
         onnx_helper.run(larger_graph, "final", first=a, second=b), (2 * (a + b) + b) / a
@@ -155,17 +155,17 @@ def add4_graph(add_proto):
     def add(x, y):
         return inline(add_proto)(A=x, B=y)["C"]
 
-    vec = Tensor(numpy.float32, (None,))
+    vec = Tensor(np.float32, (None,))
     a, b, c, d = arguments(a=vec, b=vec, c=vec, d=vec)
     r = add(add(a, b), add(c, d))
     return results(r=r)
 
 
 def test_repeated(onnx_helper, add4_graph):
-    a = numpy.array([1.5, 1.125], numpy.float32)
-    b = numpy.array([0.25, 4.5], numpy.float32)
-    c = numpy.array([4.75, 2], numpy.float32)
-    d = numpy.array([0.125, 3], numpy.float32)
+    a = np.array([1.5, 1.125], np.float32)
+    b = np.array([0.25, 4.5], np.float32)
+    c = np.array([4.75, 2], np.float32)
+    d = np.array([0.125, 3], np.float32)
     onnx_helper.assert_close(
         onnx_helper.run(add4_graph, "r", a=a, b=b, c=c, d=d), a + b + c + d
     )
@@ -176,13 +176,13 @@ def inc3_graph(inc_proto):
     def inc(s):
         return inline(inc_proto)(X=s)["Y"]
 
-    (x,) = arguments(x=Tensor(numpy.float32, (None,)))
+    (x,) = arguments(x=Tensor(np.float32, (None,)))
     y = inc(inc(inc(x)))
     return results(y=y)
 
 
 def test_inc3_with_initializer(onnx_helper, inc3_graph):
-    x = numpy.array([1.5, 0.75], numpy.float32)
+    x = np.array([1.5, 0.75], np.float32)
     onnx_helper.assert_close(onnx_helper.run(inc3_graph, "y", x=x), x + 3)
 
 
@@ -191,13 +191,13 @@ def inc3_graph_sparse_init(inc_proto_sparse_one):
     def inc(s):
         return inline(inc_proto_sparse_one)(X=s)["Y"]
 
-    (x,) = arguments(x=Tensor(numpy.float32, (None,)))
+    (x,) = arguments(x=Tensor(np.float32, (None,)))
     y = inc(inc(inc(x)))
     return results(y=y)
 
 
 def test_inc3_with_sparse_initializer(onnx_helper, inc3_graph_sparse_init):
-    x = numpy.array([1.5, 0.75], numpy.float32)
+    x = np.array([1.5, 0.75], np.float32)
     onnx_helper.assert_close(onnx_helper.run(inc3_graph_sparse_init, "y", x=x), x + 3)
 
 
@@ -205,8 +205,8 @@ def test_inc3_value_prop(inc_proto):
     def inc(s):
         return inline(inc_proto)(X=s)["Y"]
 
-    assert inc(inc(inc(op.constant(value_floats=[0.0]))))._get_value() == numpy.array(
-        [3.0], numpy.float32
+    assert inc(inc(inc(op.constant(value_floats=[0.0]))))._get_value() == np.array(
+        [3.0], np.float32
     )
 
 
@@ -218,7 +218,7 @@ def test_proj_different_outer_name(onnx_helper, proj_proto):
     graph = results(z=proj(x, y))
 
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "z", x=numpy.array([1.0]), y=numpy.array([2.0])), 2
+        onnx_helper.run(graph, "z", x=np.array([1.0]), y=np.array([2.0])), 2
     )
 
 
@@ -230,7 +230,7 @@ def test_proj_same_outer_name(onnx_helper, proj_proto):
     graph = results(c=proj(x, y))
 
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "c", a=numpy.array([1.0]), b=numpy.array([2.0])), 2
+        onnx_helper.run(graph, "c", a=np.array([1.0]), b=np.array([2.0])), 2
     )
 
 
@@ -242,7 +242,7 @@ def test_proj_composed_same_name(onnx_helper, proj_proto):
     graph = results(c=proj(y, proj(x, y)))
 
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "c", a=numpy.array([1.0]), b=numpy.array([2.0])), 2
+        onnx_helper.run(graph, "c", a=np.array([1.0]), b=np.array([2.0])), 2
     )
 
 
@@ -251,8 +251,8 @@ def test_relu_inline_subgraph(onnx_helper, relu_proto):
     (b,) = inline(relu_proto)(a).values()
     graph = results(b=b).with_arguments(a)
 
-    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=numpy.array(1.0)), 1.0)
-    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=numpy.array(-1.0)), 0.0)
+    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=np.array(1.0)), 1.0)
+    onnx_helper.assert_close(onnx_helper.run(graph, "b", a=np.array(-1.0)), 0.0)
 
 
 def test_symbolic_dim_stripped(add4_graph):
@@ -346,10 +346,10 @@ def test_subgraph_with_nodes_with_optional_inputs():
     """Unset optional inputs must not be prefixed by `inline`."""
 
     def inline_model() -> onnx.ModelProto:
-        a = argument(Tensor(numpy.float64, ("N",)))
-        return build({"a": a}, {"b": op.clip(a, None, op.const(1.0, numpy.float64))})
+        a = argument(Tensor(np.float64, ("N",)))
+        return build({"a": a}, {"b": op.clip(a, None, op.const(1.0, np.float64))})
 
-    foo = argument(Tensor(numpy.float64, ("N",)))
+    foo = argument(Tensor(np.float64, ("N",)))
     (bar,) = inline(inline_model())(foo).values()
 
     model_proto = build({"foo": foo}, {"bar": bar})

--- a/tests/test_optional.py
+++ b/tests/test_optional.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 
 import spox.opset.ai.onnx.v17 as op
 from spox._graph import arguments
@@ -6,7 +6,7 @@ from spox._type_system import Optional, Tensor
 
 
 def test_optional_type_objects():
-    (a,) = arguments(a=Tensor(numpy.int64, ()))
-    assert op.optional(a).type == Optional(Tensor(numpy.int64, ()))
-    assert op.optional(type=a.type).type == Optional(Tensor(numpy.int64, ()))
+    (a,) = arguments(a=Tensor(np.int64, ()))
+    assert op.optional(a).type == Optional(Tensor(np.int64, ()))
+    assert op.optional(type=a.type).type == Optional(Tensor(np.int64, ()))
     assert op.optional_get_element(op.optional(a)).type == a.type

--- a/tests/test_standard_op.py
+++ b/tests/test_standard_op.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any
 
-import numpy
+import numpy as np
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
@@ -12,59 +12,57 @@ from spox._type_system import Tensor
 
 
 def test_basic_inference():
-    a, b = arguments(a=Tensor(numpy.float32, ("N",)), b=Tensor(numpy.float32, (2, "N")))
-    assert op.add(a, b).type == Tensor(numpy.float32, (2, "N"))
+    a, b = arguments(a=Tensor(np.float32, ("N",)), b=Tensor(np.float32, (2, "N")))
+    assert op.add(a, b).type == Tensor(np.float32, (2, "N"))
 
 
 def test_variadic_input_inference():
-    typ = Tensor(numpy.float32, ("N",))
+    typ = Tensor(np.float32, ("N",))
     a, b, c = arguments(a=typ, b=typ, c=typ)
     assert op.max([a, b, c]).type == typ
 
 
 def test_variadic_output_inference():
-    (x,) = arguments(x=Tensor(numpy.float32, (3, "N")))
+    (x,) = arguments(x=Tensor(np.float32, (3, "N")))
     x1, x2, x3 = op.split(x, op.const([1, 1, 1]), outputs_count=3)
-    assert x1.type == x2.type == x3.type == Tensor(numpy.float32, (1, "N"))
+    assert x1.type == x2.type == x3.type == Tensor(np.float32, (1, "N"))
 
 
 def test_optional_input_inference():
-    (x,) = arguments(x=Tensor(numpy.float32, ("N",)))
+    (x,) = arguments(x=Tensor(np.float32, ("N",)))
     assert op.clip(x, max=op.constant(value_float=1.0)).type == Tensor(
-        numpy.float32, ("N",)
+        np.float32, ("N",)
     )
     assert op.clip(x, min=op.constant(value_float=0.0)).type == Tensor(
-        numpy.float32, ("N",)
+        np.float32, ("N",)
     )
     assert op.clip(
         x, min=op.constant(value_float=0.0), max=op.constant(value_float=1.0)
-    ).type == Tensor(numpy.float32, ("N",))
+    ).type == Tensor(np.float32, ("N",))
 
 
 def test_function_body_inference():
-    a, b = arguments(a=Tensor(numpy.float32, ("N",)), b=Tensor(numpy.float32, ("N",)))
-    assert op.greater_or_equal(a, b).type == Tensor(numpy.bool_, ("N",))
+    a, b = arguments(a=Tensor(np.float32, ("N",)), b=Tensor(np.float32, ("N",)))
+    assert op.greater_or_equal(a, b).type == Tensor(np.bool_, ("N",))
 
 
 def test_inference_fails():
-    a, b = arguments(a=Tensor(numpy.float32, (2,)), b=Tensor(numpy.float32, (3,)))
+    a, b = arguments(a=Tensor(np.float32, (2,)), b=Tensor(np.float32, (3,)))
     with pytest.raises((InferenceError, RuntimeError), match="InferenceError"):
         op.add(a, b)
 
 
 def test_inference_validation_fails():
-    a, b = arguments(a=Tensor(numpy.float32, (2,)), b=Tensor(numpy.float64, (2,)))
+    a, b = arguments(a=Tensor(np.float32, (2,)), b=Tensor(np.float64, (2,)))
     with pytest.raises((InferenceError, RuntimeError), match="InferenceError"):
         op.add(a, b)
 
 
 def test_multiple_outputs():
-    x, k = arguments(
-        a=Tensor(numpy.float32, ("N", "M", "K")), b=Tensor(numpy.int64, (1,))
-    )
+    x, k = arguments(a=Tensor(np.float32, ("N", "M", "K")), b=Tensor(np.int64, (1,)))
     values, indices = op.top_k(x, k)
-    assert values.unwrap_type()._subtype(Tensor(numpy.float32, ("N", "M", None)))
-    assert indices.unwrap_type()._subtype(Tensor(numpy.int64, ("N", "M", None)))
+    assert values.unwrap_type()._subtype(Tensor(np.float32, ("N", "M", None)))
+    assert indices.unwrap_type()._subtype(Tensor(np.int64, ("N", "M", None)))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-import numpy
+import numpy as np
 import pytest
 
 import spox.opset.ai.onnx.v17 as op
@@ -12,96 +12,80 @@ from spox._type_system import Sequence, Tensor
 
 
 def test_subgraph(onnx_helper):
-    (e,) = arguments(e=Tensor(numpy.int64, ()))
+    (e,) = arguments(e=Tensor(np.int64, ()))
     lp, sc = op.loop(
         v_initial=[op.constant(value_floats=[0.0])],  # Initial carry
         body=lambda iter_num, cond_in, carry_in: (
             # Stop condition: iter_num < e
             op.less(iter_num, e),
             # Carried: carry_in + iter_num
-            op.add(carry_in, op.cast(iter_num, to=numpy.float32)),
+            op.add(carry_in, op.cast(iter_num, to=np.float32)),
             # Scanned: iter_num
             iter_num,
         ),
     )
-    lp = op.reshape(lp, op.const(numpy.array([], dtype=numpy.int64)))
+    lp = op.reshape(lp, op.const(np.array([], dtype=np.int64)))
     sc = op.squeeze(sc, op.const([-1]))
     graph = results(lp=lp, sc=sc)
-    onnx_helper.assert_close(onnx_helper.run(graph, "lp", e=numpy.array(9)), [45])
-    onnx_helper.assert_close(onnx_helper.run(graph, "lp", e=numpy.array(10)), [55])
+    onnx_helper.assert_close(onnx_helper.run(graph, "lp", e=np.array(9)), [45])
+    onnx_helper.assert_close(onnx_helper.run(graph, "lp", e=np.array(10)), [55])
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "sc", e=numpy.array(5)), [0, 1, 2, 3, 4, 5]
+        onnx_helper.run(graph, "sc", e=np.array(5)), [0, 1, 2, 3, 4, 5]
     )
 
 
 def test_subgraph_copy_result(onnx_helper):
     b, x, y = arguments(
-        b=Tensor(numpy.bool_, ()), x=Tensor(numpy.int64, ()), y=Tensor(numpy.int64, ())
+        b=Tensor(np.bool_, ()), x=Tensor(np.int64, ()), y=Tensor(np.int64, ())
     )
     z1, z2 = op.if_(b, then_branch=lambda: (x, x), else_branch=lambda: (y, y))
     graph = results(z1=z1, z2=z2)
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z1", b=numpy.array(True), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z1", b=np.array(True), x=np.array(0), y=np.array(1)),
         [0],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z2", b=numpy.array(True), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z2", b=np.array(True), x=np.array(0), y=np.array(1)),
         [0],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z1", b=numpy.array(False), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z1", b=np.array(False), x=np.array(0), y=np.array(1)),
         [1],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z2", b=numpy.array(False), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z2", b=np.array(False), x=np.array(0), y=np.array(1)),
         [1],
     )
 
 
 def test_subgraph_non_copy_repeated_result(onnx_helper):
     b, x, y = arguments(
-        b=Tensor(numpy.bool_, ()), x=Tensor(numpy.int64, ()), y=Tensor(numpy.int64, ())
+        b=Tensor(np.bool_, ()), x=Tensor(np.int64, ()), y=Tensor(np.int64, ())
     )
     x = op.mul(x, op.const(2))
     y = op.mul(y, op.const(2))
     z1, z2 = op.if_(b, then_branch=lambda: (x, x), else_branch=lambda: (y, y))
     graph = results(z1=z1, z2=z2)
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z1", b=numpy.array(True), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z1", b=np.array(True), x=np.array(0), y=np.array(1)),
         [0],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z2", b=numpy.array(True), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z2", b=np.array(True), x=np.array(0), y=np.array(1)),
         [0],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z1", b=numpy.array(False), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z1", b=np.array(False), x=np.array(0), y=np.array(1)),
         [2],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(
-            graph, "z2", b=numpy.array(False), x=numpy.array(0), y=numpy.array(1)
-        ),
+        onnx_helper.run(graph, "z2", b=np.array(False), x=np.array(0), y=np.array(1)),
         [2],
     )
 
 
 def test_outer_scope_arguments(onnx_helper):
-    b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
+    b, x = arguments(b=Tensor(np.bool_, ()), x=Tensor(np.float32, (None,)))
     (r,) = op.if_(
         b, else_branch=lambda: [op.add(x, x)], then_branch=lambda: [op.mul(x, x)]
     )
@@ -110,8 +94,8 @@ def test_outer_scope_arguments(onnx_helper):
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(False),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
+            b=np.array(False),
+            x=np.array([1, 2, 3], dtype=np.float32),
         ),
         [2, 4, 6],
     )
@@ -119,8 +103,8 @@ def test_outer_scope_arguments(onnx_helper):
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(True),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
+            b=np.array(True),
+            x=np.array([1, 2, 3], dtype=np.float32),
         ),
         [1, 4, 9],
     )
@@ -128,10 +112,10 @@ def test_outer_scope_arguments(onnx_helper):
 
 def test_outer_scope_arguments_nested(onnx_helper):
     b, c, x, y = arguments(
-        b=Tensor(numpy.bool_, ()),
-        c=Tensor(numpy.bool_, ()),
-        x=Tensor(numpy.float32, (None,)),
-        y=Tensor(numpy.float32, (None,)),
+        b=Tensor(np.bool_, ()),
+        c=Tensor(np.bool_, ()),
+        x=Tensor(np.float32, (None,)),
+        y=Tensor(np.float32, (None,)),
     )
     (r,) = op.if_(
         b,
@@ -145,10 +129,10 @@ def test_outer_scope_arguments_nested(onnx_helper):
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(True),
-            c=numpy.array(False),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
-            y=numpy.array([0, 2, 1], dtype=numpy.float32),
+            b=np.array(True),
+            c=np.array(False),
+            x=np.array([1, 2, 3], dtype=np.float32),
+            y=np.array([0, 2, 1], dtype=np.float32),
         ),
         [0, 2, 1],
     )
@@ -156,10 +140,10 @@ def test_outer_scope_arguments_nested(onnx_helper):
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(True),
-            c=numpy.array(True),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
-            y=numpy.array([0, 2, 1], dtype=numpy.float32),
+            b=np.array(True),
+            c=np.array(True),
+            x=np.array([1, 2, 3], dtype=np.float32),
+            y=np.array([0, 2, 1], dtype=np.float32),
         ),
         [0, 4, 2],
     )
@@ -167,10 +151,10 @@ def test_outer_scope_arguments_nested(onnx_helper):
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(False),
-            c=numpy.array(False),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
-            y=numpy.array([0, 2, 1], dtype=numpy.float32),
+            b=np.array(False),
+            c=np.array(False),
+            x=np.array([1, 2, 3], dtype=np.float32),
+            y=np.array([0, 2, 1], dtype=np.float32),
         ),
         [1, 2, 3],
     )
@@ -178,10 +162,10 @@ def test_outer_scope_arguments_nested(onnx_helper):
 
 def test_outer_scope_arguments_nested_used_in_both(onnx_helper):
     b, c, x, y = arguments(
-        b=Tensor(numpy.bool_, ()),
-        c=Tensor(numpy.bool_, ()),
-        x=Tensor(numpy.float32, (None,)),
-        y=Tensor(numpy.float32, (None,)),
+        b=Tensor(np.bool_, ()),
+        c=Tensor(np.bool_, ()),
+        x=Tensor(np.float32, (None,)),
+        y=Tensor(np.float32, (None,)),
     )
     # An argument is used only in a nested context, and then also afterwards.
     (r,) = op.if_(
@@ -201,9 +185,9 @@ def test_subgraph_argument_used_only_in_subsubgraph(onnx_helper):
         M=op.const([5]),
         v_initial=[],
         body=lambda i, _: (
-            op.const(numpy.array(True)),
+            op.const(np.array(True)),
             op.if_(
-                op.const(numpy.array(True)),
+                op.const(np.array(True)),
                 else_branch=lambda: [op.const([0])],
                 then_branch=lambda: [i],
             )[0],
@@ -214,31 +198,31 @@ def test_subgraph_argument_used_only_in_subsubgraph(onnx_helper):
 
 
 def test_copied_outer_argument(onnx_helper):
-    b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
+    b, x = arguments(b=Tensor(np.bool_, ()), x=Tensor(np.float32, (None,)))
     (r,) = op.if_(b, else_branch=lambda: [x], then_branch=lambda: [x])
     graph = results(r=op.add(x, r))
     onnx_helper.assert_close(
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(False),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
+            b=np.array(False),
+            x=np.array([1, 2, 3], dtype=np.float32),
         ),
         [2, 4, 6],
     )
 
 
 def test_outer_scope_argument_used_only_inner(onnx_helper):
-    b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.float32, (None,)))
-    two = op.const(numpy.float32(2.0))
+    b, x = arguments(b=Tensor(np.bool_, ()), x=Tensor(np.float32, (None,)))
+    two = op.const(np.float32(2.0))
     (r,) = op.if_(b, else_branch=lambda: [x], then_branch=lambda: [op.mul(two, x)])
     graph = results(r=r)
     onnx_helper.assert_close(
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(False),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
+            b=np.array(False),
+            x=np.array([1, 2, 3], dtype=np.float32),
         ),
         [1, 2, 3],
     )
@@ -246,15 +230,15 @@ def test_outer_scope_argument_used_only_inner(onnx_helper):
         onnx_helper.run(
             graph,
             "r",
-            b=numpy.array(True),
-            x=numpy.array([1, 2, 3], dtype=numpy.float32),
+            b=np.array(True),
+            x=np.array([1, 2, 3], dtype=np.float32),
         ),
         [2, 4, 6],
     )
 
 
 def test_subgraph_arguments_kept_separate(onnx_helper):
-    a, b = arguments(a=Tensor(numpy.int64, ()), b=Tensor(numpy.int64, ()))
+    a, b = arguments(a=Tensor(np.int64, ()), b=Tensor(np.int64, ()))
 
     x, y = op.loop(
         v_initial=[a, b],  # _a = a, _b = b
@@ -267,56 +251,52 @@ def test_subgraph_arguments_kept_separate(onnx_helper):
         ),  # -> (_a, _b) = (a, b)
     )  # (a, b)
 
-    x = op.reshape(x, op.const(numpy.array([], dtype=numpy.int64)))
-    y = op.reshape(y, op.const(numpy.array([], dtype=numpy.int64)))
+    x = op.reshape(x, op.const(np.array([], dtype=np.int64)))
+    y = op.reshape(y, op.const(np.array([], dtype=np.int64)))
 
     onnx_helper.assert_close(
         onnx_helper.run(
             results(x=x, y=y),
             "x",
-            a=numpy.array(0),
-            b=numpy.array(1),
+            a=np.array(0),
+            b=np.array(1),
         ),
         0,
     )
 
 
 def test_scan_for_product(onnx_helper):
-    (x,) = arguments(x=Tensor(numpy.int32, ("N",)))
-    one = op.const(numpy.array(1, dtype=numpy.int32))
+    (x,) = arguments(x=Tensor(np.int32, ("N",)))
+    one = op.const(np.array(1, dtype=np.int32))
     prod, _x = op.scan([one, x], body=lambda a, p: [op.mul(a, p), a], num_scan_inputs=1)
     onnx_helper.assert_close(
         onnx_helper.run(
             results(prod=prod),
             "prod",
-            x=numpy.array([1, 2, 3, 4, 5], dtype=numpy.int32),
+            x=np.array([1, 2, 3, 4, 5], dtype=np.int32),
         ),
-        numpy.array(1 * 2 * 3 * 4 * 5, numpy.int32),
+        np.array(1 * 2 * 3 * 4 * 5, np.int32),
     )
 
 
 def test_sequence_map_for_zip_mul(onnx_helper):
-    xs, ys = arguments(
-        xs=Sequence(Tensor(numpy.int64)), ys=Sequence(Tensor(numpy.int64))
-    )
+    xs, ys = arguments(xs=Sequence(Tensor(np.int64)), ys=Sequence(Tensor(np.int64)))
     (zs,) = op.sequence_map(xs, [ys], body=lambda x, y: (op.mul(x, y),))
     onnx_helper.assert_close(
         onnx_helper.run(
             results(zs=zs),
             "zs",
-            xs=[numpy.array([1]), numpy.array([2]), numpy.array([3])],
-            ys=[numpy.array([-1]), numpy.array([0]), numpy.array([1])],
+            xs=[np.array([1]), np.array([2]), np.array([3])],
+            ys=[np.array([-1]), np.array([0]), np.array([1])],
         ),
-        [numpy.array([-1]), numpy.array([0]), numpy.array([3])],
+        [np.array([-1]), np.array([0]), np.array([3])],
     )
 
 
 def test_graph_inherits_subgraph_opset_req(onnx_helper):
     import spox.opset.ai.onnx.ml.v3 as ml
 
-    xs, ys = arguments(
-        xs=Sequence(Tensor(numpy.int64)), ys=Sequence(Tensor(numpy.int64))
-    )
+    xs, ys = arguments(xs=Sequence(Tensor(np.int64)), ys=Sequence(Tensor(np.int64)))
     (zs,) = op.sequence_map(
         xs,
         [ys],
@@ -330,25 +310,25 @@ def test_graph_inherits_subgraph_opset_req(onnx_helper):
         onnx_helper.run(
             results(zs=zs),
             "zs",
-            xs=[numpy.array([1]), numpy.array([2]), numpy.array([3])],
-            ys=[numpy.array([-1]), numpy.array([0]), numpy.array([1])],
+            xs=[np.array([1]), np.array([2]), np.array([3])],
+            ys=[np.array([-1]), np.array([0]), np.array([1])],
         ),
-        [numpy.array([-2]), numpy.array([0]), numpy.array([6])],
+        [np.array([-2]), np.array([0]), np.array([6])],
     )
 
 
 def test_subgraph_result_depends_on_result(onnx_helper):
-    b, x = arguments(b=Tensor(numpy.bool_, ()), x=Tensor(numpy.int64, ()))
+    b, x = arguments(b=Tensor(np.bool_, ()), x=Tensor(np.int64, ()))
     x = op.mul(x, op.const(2))
     x1 = op.add(x, op.const(1))
     z1, z2 = op.if_(b, then_branch=lambda: (x, x1), else_branch=lambda: (x1, x))
     graph = results(z1=z1, z2=z2)
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "z1", b=numpy.array(True), x=numpy.array(5)),
+        onnx_helper.run(graph, "z1", b=np.array(True), x=np.array(5)),
         [10],
     )
     onnx_helper.assert_close(
-        onnx_helper.run(graph, "z2", b=numpy.array(True), x=numpy.array(5)),
+        onnx_helper.run(graph, "z2", b=np.array(True), x=np.array(5)),
         [11],
     )
 
@@ -428,8 +408,8 @@ def test_subgraph_basic_initializer(onnx_helper):
         e, then_branch=lambda: [initializer(0)], else_branch=lambda: [op.const(1)]
     )
     graph = results(f=f)
-    onnx_helper.assert_close(onnx_helper.run(graph, "f", e=numpy.array(True)), [0])
-    onnx_helper.assert_close(onnx_helper.run(graph, "f", e=numpy.array(False)), [1])
+    onnx_helper.assert_close(onnx_helper.run(graph, "f", e=np.array(True)), [0])
+    onnx_helper.assert_close(onnx_helper.run(graph, "f", e=np.array(False)), [1])
 
 
 def test_subgraph_argument_leak_caught():

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,11 +1,11 @@
-import numpy
+import numpy as np
 import pytest
 
 from spox._shape import Constant, Natural, Shape, ShapeError, Unknown
 from spox._type_system import Tensor
 
 
-@pytest.fixture(params=[numpy.float64, numpy.int32, numpy.bool_])
+@pytest.fixture(params=[np.float64, np.int32, np.bool_])
 def scalar_type(request):
     return request.param
 
@@ -66,7 +66,7 @@ def test_tensor_shorthand(scalar_type, shape_pair):
 
 
 def test_bad_tensor_type():
-    assert Tensor(numpy.float32) != Tensor(numpy.float64)  # sanity check
-    for typ in (numpy.object_, object, None):
+    assert Tensor(np.float32) != Tensor(np.float64)  # sanity check
+    for typ in (np.object_, object, None):
         with pytest.raises(TypeError):
             Tensor(typ)

--- a/tests/test_type_translation.py
+++ b/tests/test_type_translation.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 
-import numpy
+import numpy as np
 import onnx
 import pytest
 
@@ -14,19 +14,19 @@ def tensor_type_proto(elem_type, shape):
 
 
 def tensor_shape_proto(shape):
-    proto = tensor_type_proto(numpy.float32, shape)
+    proto = tensor_type_proto(np.float32, shape)
     return proto.tensor_type.shape if proto.tensor_type.HasField("shape") else None
 
 
 @pytest.fixture
 def tensor_elem_type_pairs():
     return [
-        (numpy.float32, onnx.TensorProto.FLOAT),
-        (numpy.float64, onnx.TensorProto.DOUBLE),
-        (numpy.int32, onnx.TensorProto.INT32),
-        (numpy.int64, onnx.TensorProto.INT64),
-        (numpy.bool_, onnx.TensorProto.BOOL),
-        (numpy.str_, onnx.TensorProto.STRING),
+        (np.float32, onnx.TensorProto.FLOAT),
+        (np.float64, onnx.TensorProto.DOUBLE),
+        (np.int32, onnx.TensorProto.INT32),
+        (np.int64, onnx.TensorProto.INT64),
+        (np.bool_, onnx.TensorProto.BOOL),
+        (np.str_, onnx.TensorProto.STRING),
     ]
 
 
@@ -40,16 +40,16 @@ def tensor_shape_pairs():
 
 @pytest.fixture
 def type_pairs() -> List[Tuple[Type, onnx.TypeProto]]:
-    tensor_f32 = tensor_type_proto(numpy.float32, None)
+    tensor_f32 = tensor_type_proto(np.float32, None)
     seq_tensor_f32 = onnx.helper.make_sequence_type_proto(tensor_f32)
     opt_seq_tensor_f32 = onnx.helper.make_optional_type_proto(seq_tensor_f32)
     return [
-        (Tensor(numpy.float32), tensor_f32),
-        (Sequence(Tensor(numpy.float32)), seq_tensor_f32),
-        (Optional(Sequence(Tensor(numpy.float32))), opt_seq_tensor_f32),
-        (Tensor(numpy.int32, ("N", 1, 2)), tensor_type_proto(numpy.int32, ("N", 1, 2))),
-        (Tensor(numpy.bool_, ()), tensor_type_proto(numpy.bool_, ())),
-        (Tensor(numpy.str_, (None,)), tensor_type_proto(numpy.str_, (None,))),
+        (Tensor(np.float32), tensor_f32),
+        (Sequence(Tensor(np.float32)), seq_tensor_f32),
+        (Optional(Sequence(Tensor(np.float32))), opt_seq_tensor_f32),
+        (Tensor(np.int32, ("N", 1, 2)), tensor_type_proto(np.int32, ("N", 1, 2))),
+        (Tensor(np.bool_, ()), tensor_type_proto(np.bool_, ())),
+        (Tensor(np.str_, (None,)), tensor_type_proto(np.str_, (None,))),
     ]
 
 
@@ -64,7 +64,7 @@ def test_tensor_elem_type_from_onnx(tensor_elem_type_pairs):
 
 
 def test_scalar_is_not_unknown_shape():
-    assert Tensor(numpy.float32)._to_onnx() != Tensor(numpy.float32, ())._to_onnx()
+    assert Tensor(np.float32)._to_onnx() != Tensor(np.float32, ())._to_onnx()
     assert Shape.from_simple(None) != Shape.from_simple(())
     assert Shape.from_simple(None).to_onnx() != Shape.from_simple(()).to_onnx()
 

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import onnx
 import pytest
 
@@ -39,10 +39,10 @@ def assert_equal_value(var: Var, expected: ORTValue):
     assert var._value is not None, "var.value expected to be known"
     value = var._value.to_ort_value()
     if isinstance(var.type, _type_system.Tensor):
-        expected = numpy.array(expected)
+        expected = np.array(expected)
         assert var.type.dtype.type == expected.dtype.type, "element type must match"
         assert Shape.from_simple(expected.shape) <= var.type._shape, "shape must match"
-        numpy.testing.assert_allclose(value, expected)
+        np.testing.assert_allclose(value, expected)
     elif isinstance(var.type, _type_system.Optional):
         if expected is None:
             assert value is None, "value must be Nothing when optional is empty"
@@ -68,22 +68,22 @@ def assert_equal_value(var: Var, expected: ORTValue):
 
 
 def test_sanity_no_prop():
-    (x,) = arguments(x=_type_system.Tensor(numpy.int64, ()))
+    (x,) = arguments(x=_type_system.Tensor(np.int64, ()))
     op.add(x, x)
 
 
 def test_sanity_const():
-    assert_equal_value(op.const(2), numpy.int64(2))
+    assert_equal_value(op.const(2), np.int64(2))
 
 
 def test_add():
-    assert_equal_value(op.add(op.const(2), op.const(2)), numpy.int64(4))
+    assert_equal_value(op.add(op.const(2), op.const(2)), np.int64(4))
 
 
 def test_div():
     assert_equal_value(
-        op.div(op.const(numpy.float32(5.0)), op.const(numpy.float32(2.0))),
-        numpy.float32(2.5),
+        op.div(op.const(np.float32(5.0)), op.const(np.float32(2.0))),
+        np.float32(2.5),
     )
 
 
@@ -91,8 +91,8 @@ def test_identity():
     for x in [
         5,
         [1, 2, 3],
-        numpy.array([[1, 2], [3, 4], [5, 6]]),
-        numpy.array(0.5, dtype=numpy.float32),
+        np.array([[1, 2], [3, 4], [5, 6]]),
+        np.array(0.5, dtype=np.float32),
     ]:
         assert_equal_value(op.const(x), x)
 
@@ -104,28 +104,26 @@ def test_reshape():
 
 
 def test_optional():
-    assert_equal_value(op.optional(op.const(numpy.float32(2.0))), numpy.float32(2.0))
+    assert_equal_value(op.optional(op.const(np.float32(2.0))), np.float32(2.0))
 
 
 def test_empty_optional():
-    assert_equal_value(op.optional(type=_type_system.Tensor(numpy.float32, ())), None)
+    assert_equal_value(op.optional(type=_type_system.Tensor(np.float32, ())), None)
 
 
 def test_empty_optional_has_no_element():
     assert_equal_value(
-        op.optional_has_element(
-            op.optional(type=_type_system.Tensor(numpy.float32, ()))
-        ),
+        op.optional_has_element(op.optional(type=_type_system.Tensor(np.float32, ()))),
         False,
     )
 
 
 def test_sequence_empty():
-    assert_equal_value(op.sequence_empty(dtype=numpy.float32), [])
+    assert_equal_value(op.sequence_empty(dtype=np.float32), [])
 
 
 def test_sequence_append():
-    emp = op.sequence_empty(dtype=numpy.int64)
+    emp = op.sequence_empty(dtype=np.int64)
     assert_equal_value(
         op.sequence_insert(op.sequence_insert(emp, op.const(2)), op.const(1)), [2, 1]
     )
@@ -133,8 +131,8 @@ def test_sequence_append():
 
 def test_with_reconstruct():
     a, b = arguments(
-        a=_type_system.Tensor(numpy.int64, ()),
-        b=_type_system.Tensor(numpy.int64, ()),
+        a=_type_system.Tensor(np.int64, ()),
+        b=_type_system.Tensor(np.int64, ()),
     )
     c = op.add(a, b)
     graph = (
@@ -156,7 +154,7 @@ def test_bad_reshape_fails(caplog):
 def test_give_up_silently():
     # The LabelEncoder currently has no reference implementation.
     ml.label_encoder(
-        op.const(numpy.array(["foo"])),
+        op.const(np.array(["foo"])),
         keys_strings=["foo"],
         values_int64s=[42],
         default_int64=-1,
@@ -169,9 +167,9 @@ def test_non_ascii_characters_in_string_tensor():
 
 def test_propagated_value_does_not_alias_dtype():
     # Ensures that platform-dependent dtypes aren't accidentally propagated
-    x = numpy.iinfo(numpy.int64).max + 1
+    x = np.iinfo(np.int64).max + 1
     # Without the explicit astype(uint64), x actually ends up being ulonglong
-    assert_equal_value(op.const(x), numpy.array(x).astype(numpy.uint64))
+    assert_equal_value(op.const(x), np.array(x).astype(np.uint64))
 
 
 def test_value_propagation_does_not_fail_on_unseen_opsets(value_prop_backend):
@@ -206,4 +204,4 @@ def test_value_propagation_does_not_fail_on_unseen_opsets(value_prop_backend):
         ],
     )
 
-    spox.inline(model)(X=op.const(["Test Test"], dtype=numpy.str_))
+    spox.inline(model)(X=op.const(["Test Test"], dtype=np.str_))


### PR DESCRIPTION
Change the import of NumPy form `import numpy` to the conventional `import numpy as np`. There are no other changes in this PR. 

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
