### PR TITLE
Allow inline model to accept superset inputs (more inputs than expected)

### DIFF
--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -289,7 +289,7 @@ def inline(model: onnx.ModelProto) -> _InlineCall:
                 array = array.astype(str)
             kwargs[name] = initializer(array)
 
-        if set(kwargs) != set(in_names):
+        if not set(in_names).issubset(set(kwargs)):
             raise TypeError(
                 f"Error processing arguments, got {set(kwargs)}, expected {set(in_names)}."
             )


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

<!--
Thank you for the pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Currently inline models expect the supplied arguments to be the exact same set of its expected inputs.

Logically, as a sub-model of a bigger model, it should be able to handle superset input arguments that are passed down from main model.

This closes #171 

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
