### PR TITLE
Add "const" to __all__

### DIFF
--- a/src/spox/opset/ai/onnx/v17.py
+++ b/src/spox/opset/ai/onnx/v17.py
@@ -15867,4 +15867,4 @@ _CONSTRUCTORS = {
     "Xor": xor,
 }
 
-__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()]
+__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()] + ["const"]

--- a/src/spox/opset/ai/onnx/v18.py
+++ b/src/spox/opset/ai/onnx/v18.py
@@ -3200,4 +3200,4 @@ _CONSTRUCTORS = {
     "Xor": xor,
 }
 
-__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()]
+__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()] + ["const"]

--- a/src/spox/opset/ai/onnx/v19.py
+++ b/src/spox/opset/ai/onnx/v19.py
@@ -3008,4 +3008,4 @@ _CONSTRUCTORS = {
     "Xor": xor,
 }
 
-__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()]
+__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()] + ["const"]

--- a/src/spox/opset/ai/onnx/v20.py
+++ b/src/spox/opset/ai/onnx/v20.py
@@ -1914,4 +1914,4 @@ _CONSTRUCTORS = {
     "Xor": xor,
 }
 
-__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()]
+__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()] + ["const"]

--- a/src/spox/opset/ai/onnx/v21.py
+++ b/src/spox/opset/ai/onnx/v21.py
@@ -3010,4 +3010,4 @@ _CONSTRUCTORS = {
     "Xor": xor,
 }
 
-__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()]
+__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()] + ["const"]

--- a/tools/generate_opset.py
+++ b/tools/generate_opset.py
@@ -496,7 +496,8 @@ def write_schemas_code(
 
     print(
         env.get_template("summary.jinja2").render(
-            built_names=sorted({schema.name for schema in schemas})
+            built_names=sorted({schema.name for schema in schemas}),
+            domain=domain,
         ),
         file=file,
         end="\n",

--- a/tools/templates/summary.jinja2
+++ b/tools/templates/summary.jinja2
@@ -10,4 +10,4 @@ _CONSTRUCTORS = {
 {% endfor %}
 }
 
-__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()]
+__all__ = [fun.__name__ for fun in _CONSTRUCTORS.values()] {% if domain == "ai.onnx" %} + ["const"] {% endif %}


### PR DESCRIPTION
This PR adds `"const"` to the default opsets' (`ai.onnx`) `__all__`. This will cause `const` to be correctly rendered in our documentation.