### PR TITLE
Remove logic around `Initializer`-s in `adapt_node`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Change log
 
 - Value propagation of string tensors no longer raises an erroneous ``ValueError`` in some instances.
 
+**Other changes**
+
+- The adaption logic is not using inferred values as initializers anymore.
+
 
 0.12.1 (2024-06-18)
 -------------------

--- a/src/spox/_adapt.py
+++ b/src/spox/_adapt.py
@@ -4,7 +4,6 @@
 import warnings
 from typing import Optional
 
-import numpy as np
 import onnx
 import onnx.version_converter
 
@@ -14,7 +13,6 @@ from ._internal_op import _InternalNode
 from ._node import Node
 from ._schemas import SCHEMAS
 from ._scope import Scope
-from ._utils import from_array
 from ._var import Var
 
 
@@ -43,11 +41,6 @@ def adapt_node(
             )
             for key, var in node.outputs.get_vars().items()
         ]
-        initializers = [
-            from_array(var._value, name)  # type: ignore
-            for name, var in node.inputs.get_vars().items()
-            if isinstance(var._value, np.ndarray)
-        ]
     except ValueError:
         return None
 
@@ -57,7 +50,6 @@ def adapt_node(
             "spox__singleton_adapter_graph",
             list(input_info.values()),
             output_info,
-            initializers,
         ),
         opset_imports=[onnx.helper.make_operatorsetid("", source_version)],
     )

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -15,6 +15,7 @@ import spox.opset.ai.onnx.v19 as op19
 from spox import Tensor, Var, argument, build, inline
 from spox._attributes import AttrInt64s
 from spox._fields import BaseAttributes, BaseInputs, BaseOutputs
+from spox._future import initializer
 from spox._graph import arguments, results
 from spox._node import OpType
 from spox._standard import StandardNode
@@ -155,6 +156,18 @@ def test_adapt_node_with_repeating_input_names():
     c = op19.identity(a)
 
     build({"a": a}, {"b": b, "c": c})
+
+
+def test_adapt_node_initializer():
+    init_data = [1.0, 2.0, 3.0]
+
+    a = argument(Tensor(np.float32, ("N",)))
+    b = initializer(init_data, np.float32)
+    c = op18.equal(a, b)
+    d = op19.identity(a)
+
+    model = build({"a": a}, {"b": b, "c": c, "d": d})
+    np.testing.assert_allclose(model.graph.initializer[0].float_data, init_data)
 
 
 def test_inline_model_custom_node_only():


### PR DESCRIPTION
Currently it seems like `adapt_node` uses some of the constant propagated values as initialisers to the adapted node. 

After discussing this with @cbourjau it seems like it may be a legacy artefact as it does not break anything downstream. It may have existed in a way to ensure that the initialisers are properly put into the graph, however as demonstrated by the test case they get picked as attributes during the build procedure. 

# Checklist

- [X] Added a `CHANGELOG.rst` entry
