### PR TITLE
Deprecate operator dispatch in `Var`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Change log
 
 **Pending breaking changes**
 
-- Usage of operator overloading via ``_operator_dispatcher`` now triggers a ``DeprecationWarning``. This API is scheduled for removal in Spox ``0.14.0``. Consider using ``ndonnx`` as an alternative.
+- Usage of ``operator_overloading`` now triggers a ``DeprecationWarning``. This API is scheduled for removal in Spox ``0.14.0``. Consider using ``ndonnx`` as an alternative.
 
 **Other changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Change log
 
 **Pending breaking changes**
 
-- Usage of ``operator_overloading`` now triggers a ``DeprecationWarning``. This API is scheduled for removal in Spox ``0.14.0``. Consider using ``ndonnx`` as an alternative.
+- Importing :func:`spox._future.operator_overloading`` now triggers a ``DeprecationWarning``. The function will be removed in a future release. Consider using ``ndonnx`` as an alternative.
 
 **Other changes**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Change log
 
 - Value propagation of string tensors no longer raises an erroneous ``ValueError`` in some instances.
 
+**Pending breaking changes**
+
+- Usage of operator overloading via ``_operator_dispatcher`` now triggers a ``DeprecationWarning``. This API is scheduled for removal in Spox ``0.14.0``. Consider using ``ndonnx`` as an alternative.
+
 **Other changes**
 
 - The adaption logic is not using inferred values as initializers anymore.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Change log
 
 - Value propagation of string tensors no longer raises an erroneous ``ValueError`` in some instances.
 
-**Pending breaking changes**
+**Deprecation**
 
 - Importing :func:`spox._future.operator_overloading`` now triggers a ``DeprecationWarning``. The function will be removed in a future release. Consider using ``ndonnx`` as an alternative.
 

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -3,6 +3,7 @@
 
 """Module containing experimental Spox features that may be standard in the future."""
 
+import warnings
 from collections.abc import Iterable
 from contextlib import contextmanager
 from typing import Optional, Union
@@ -201,6 +202,10 @@ def operator_overloading(
     ...    return x * y
     >>> assert foo()._get_value() == np.array(6)
     """
+    warnings.warn(
+        "using operator_overloading is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+        DeprecationWarning,
+    )
     prev_dispatcher = Var._operator_dispatcher
     Var._operator_dispatcher = _NumpyLikeOperatorDispatcher(
         op, type_promotion, constant_promotion

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -232,5 +232,4 @@ __all__ = [
     "ValuePropBackend",
     "set_value_prop_backend",
     "value_prop_backend",
-    # Operator overloading on Var
 ]

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -165,7 +165,7 @@ class _NumpyLikeOperatorDispatcher:
 
 
 @contextmanager
-def operator_overloading(
+def _operator_overloading(
     op, type_promotion: bool = False, constant_promotion: bool = True
 ):
     """Enable operator overloading on Var for this block.
@@ -202,16 +202,23 @@ def operator_overloading(
     ...    return x * y
     >>> assert foo()._get_value() == np.array(6)
     """
-    warnings.warn(
-        "using operator_overloading is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-        DeprecationWarning,
-    )
     prev_dispatcher = Var._operator_dispatcher
     Var._operator_dispatcher = _NumpyLikeOperatorDispatcher(
         op, type_promotion, constant_promotion
     )
     yield
     Var._operator_dispatcher = prev_dispatcher
+
+
+def __getattr__(name):
+    if name == "operator_overloading":
+        warnings.warn(
+            "using 'operator_overloading' is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
+        return _operator_overloading
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 __all__ = [
@@ -226,5 +233,6 @@ __all__ = [
     "set_value_prop_backend",
     "value_prop_backend",
     # Operator overloading on Var
-    "operator_overloading",
+    "operator_overloading",  # noqa: F822
+    "__getattr__",
 ]

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -233,6 +233,4 @@ __all__ = [
     "set_value_prop_backend",
     "value_prop_backend",
     # Operator overloading on Var
-    "operator_overloading",  # noqa: F822
-    "__getattr__",
 ]

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -1,7 +1,6 @@
 # Copyright (c) QuantCo 2023-2024
 # SPDX-License-Identifier: BSD-3-Clause
 import typing
-import warnings
 from typing import Any, Callable, ClassVar, Optional, TypeVar, Union
 
 import numpy as np
@@ -144,129 +143,57 @@ class Var:
         raise ValueError("'Var' objects cannot be deepcopied.")
 
     def __add__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.add(self, other)
 
     def __sub__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.sub(self, other)
 
     def __mul__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.mul(self, other)
 
     def __truediv__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.truediv(self, other)
 
     def __floordiv__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.floordiv(self, other)
 
     def __neg__(self) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.neg(self)
 
     def __and__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.and_(self, other)
 
     def __or__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.or_(self, other)
 
     def __xor__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.xor(self, other)
 
     def __invert__(self) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.not_(self)
 
     def __radd__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.add(other, self)
 
     def __rsub__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.sub(other, self)
 
     def __rmul__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.mul(other, self)
 
     def __rtruediv__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.truediv(other, self)
 
     def __rfloordiv__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.floordiv(other, self)
 
     def __rand__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.and_(other, self)
 
     def __ror__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.or_(other, self)
 
     def __rxor__(self, other) -> "Var":
-        warnings.warn(
-            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
-            DeprecationWarning,
-        )
         return Var._operator_dispatcher.xor(other, self)
 
 

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -1,7 +1,7 @@
 # Copyright (c) QuantCo 2023-2024
 # SPDX-License-Identifier: BSD-3-Clause
-
 import typing
+import warnings
 from typing import Any, Callable, ClassVar, Optional, TypeVar, Union
 
 import numpy as np
@@ -144,57 +144,129 @@ class Var:
         raise ValueError("'Var' objects cannot be deepcopied.")
 
     def __add__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.add(self, other)
 
     def __sub__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.sub(self, other)
 
     def __mul__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.mul(self, other)
 
     def __truediv__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.truediv(self, other)
 
     def __floordiv__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.floordiv(self, other)
 
     def __neg__(self) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.neg(self)
 
     def __and__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.and_(self, other)
 
     def __or__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.or_(self, other)
 
     def __xor__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.xor(self, other)
 
     def __invert__(self) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.not_(self)
 
     def __radd__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.add(other, self)
 
     def __rsub__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.sub(other, self)
 
     def __rmul__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.mul(other, self)
 
     def __rtruediv__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.truediv(other, self)
 
     def __rfloordiv__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.floordiv(other, self)
 
     def __rand__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.and_(other, self)
 
     def __ror__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.or_(other, self)
 
     def __rxor__(self, other) -> "Var":
+        warnings.warn(
+            "using _operator_dispatcher is deprecated, consider using https://github.com/Quantco/ndonnx instead",
+            DeprecationWarning,
+        )
         return Var._operator_dispatcher.xor(other, self)
 
 

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -1,5 +1,6 @@
 # Copyright (c) QuantCo 2023-2024
 # SPDX-License-Identifier: BSD-3-Clause
+
 import typing
 from typing import Any, Callable, ClassVar, Optional, TypeVar, Union
 


### PR DESCRIPTION
Operator dispatch is a too high-level feature for `spox`. Also it is currently clunky to use from a user standpoint as it essentially "monkey-patches" the dispatcher in `spox`.  

A more appropriate way to access this behaviour is by using [ndonnx](https://github.com/Quantco/ndonnx).

# Checklist

- [X] Added a `CHANGELOG.rst` entry
