### PR TITLE
Remove unused `type:ignore`-s

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ def linkcode_resolve(domain, info):
     try:
         source, line_number = inspect.getsourcelines(_object)
     except OSError:
-        line_number = None  # type: ignore
+        line_number = None
 
     if line_number:
         linespec = f"#L{line_number}-L{line_number + len(source) - 1}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ python_version = "3.9"
 ignore_missing_imports = true
 no_implicit_optional = true
 check_untyped_defs = true
+warn_unused_ignores = true
 
 [tool.pytest.ini_options]
 # This will be pytest's future default.

--- a/src/spox/_function.py
+++ b/src/spox/_function.py
@@ -76,7 +76,7 @@ class Function(_InternalNode):
                 )
             self.func_attrs[name] = attr
 
-        self.func_inputs = self.Inputs(**self.func_args)  # type: ignore
+        self.func_inputs = self.Inputs(**self.func_args)
         self.func_outputs = self.constructor(self.func_attrs, self.func_inputs)
         self.func_graph = _graph.results(**self.func_outputs.get_vars()).with_arguments(
             *self.func_args.values()

--- a/src/spox/_graph.py
+++ b/src/spox/_graph.py
@@ -399,7 +399,7 @@ class Graph:
                 "Consider adding an Identity operator if you are just copying arguments."
             )
 
-        opset_req: list[tuple[str, int]] = list(opsets.items())  # type: ignore
+        opset_req: list[tuple[str, int]] = list(opsets.items())
         function_protos: dict[tuple[str, str], onnx.FunctionProto] = {}
         for fun in self._get_build_result().functions:
             proto = fun.to_onnx_function(extra_opset_req=opset_req)

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -319,7 +319,7 @@ class Node(ABC):
             outputs[variadic] = [
                 Var(self, None, None) for _ in range(self.out_variadic)
             ]
-        return self.Outputs(**outputs)  # type: ignore
+        return self.Outputs(**outputs)
 
     @property
     def dependencies(self) -> Iterable[Var]:

--- a/src/spox/_schemas.py
+++ b/src/spox/_schemas.py
@@ -53,7 +53,7 @@ def _get_schemas_versioned(
     """Get a map into a list of schemas for all domain/names."""
     return {
         domain: {
-            name: sorted(op_group, key=lambda s: s.since_version)  # type: ignore
+            name: sorted(op_group, key=lambda s: s.since_version)
             for name, op_group in _key_groups(domain_group, lambda s: s.name)
         }
         for domain, domain_group in _key_groups(all_schemas, lambda s: s.domain)

--- a/src/spox/opset/ai/onnx/ml/v3.py
+++ b/src/spox/opset/ai/onnx/ml/v3.py
@@ -52,7 +52,7 @@ class _ArrayFeatureExtractor(StandardNode):
             raise InferenceError("Input `Y` must be of rank 1.")
         if len(xt.shape) == 1:
             return {"Z": Tensor(xt.dtype, (1, yt.shape[-1]))}
-        shape = tuple(list(xt.shape[:-1]) + [yt.shape[-1]])  # type: ignore
+        shape = tuple(list(xt.shape[:-1]) + [yt.shape[-1]])
         return {"Z": Tensor(xt.dtype, shape)}
 
     op_type = OpType("ArrayFeatureExtractor", "ai.onnx.ml", 1)
@@ -132,7 +132,7 @@ class _CategoryMapper(StandardNode):
         if len(cats1.value) != len(cats2.value):
             raise InferenceError("Categories lists have mismatched lengths.")
         t = self.inputs.X.unwrap_tensor()
-        (elem_type,) = {np.int64, np.str_} - {t.dtype.type}  # type: ignore
+        (elem_type,) = {np.int64, np.str_} - {t.dtype.type}
         return {"Y": Tensor(elem_type, t.shape)}
 
     op_type = OpType("CategoryMapper", "ai.onnx.ml", 1)

--- a/tools/generate_opset.py
+++ b/tools/generate_opset.py
@@ -182,7 +182,7 @@ def get_attributes(
                 name=name,
                 _member_type=member_type,
                 constructor_type_hint=constructor_type_hint,
-                constructor_default=default,  # type: ignore
+                constructor_default=default,
                 subgraph_solution=subgraph_solutions.get(name),
                 allow_extra=allow_extra,
             )

--- a/tools/templates/type_inference/arrayfeatureextractor1.jinja2
+++ b/tools/templates/type_inference/arrayfeatureextractor1.jinja2
@@ -9,5 +9,5 @@ if len(yt.shape) != 1:
     raise InferenceError("Input `Y` must be of rank 1.")
 if len(xt.shape) == 1:
     return {"Z": Tensor(xt.dtype, (1, yt.shape[-1]))}
-shape = tuple(list(xt.shape[:-1]) + [yt.shape[-1]])  # type: ignore
+shape = tuple(list(xt.shape[:-1]) + [yt.shape[-1]])
 return {"Z": Tensor(xt.dtype, shape)}

--- a/tools/templates/type_inference/categorymapper1.jinja2
+++ b/tools/templates/type_inference/categorymapper1.jinja2
@@ -6,5 +6,5 @@ if cats1 is None or cats2 is None:
 if len(cats1.value) != len(cats2.value):
     raise InferenceError("Categories lists have mismatched lengths.")
 t = self.inputs.X.unwrap_tensor()
-(elem_type,) = {np.int64, np.str_} - {t.dtype.type}  # type: ignore
+(elem_type,) = {np.int64, np.str_} - {t.dtype.type}
 return {"Y": Tensor(elem_type, t.shape)}


### PR DESCRIPTION
Upon reviewing the codebase, it appears that certain instances of `type: ignore` may not be necessary. As part of our aims to release `spox` 1.0, we should work towards strengthening our `mypy` setup to help with future maintenance.

I am open to hearing your comments. 

# Checklist

- [ ] Added a `CHANGELOG.rst` entry
