### PR TITLE
Introduce internal interface for `ValuePropBackend`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change log
 
 - Adds missing shape inference logic for :func:`spox.opsets.ai.v19.loop` and :func:`spox.opsets.ai.v21.loop`.
 
+**Deprecation**
+
+- Using :func:`spox._future.set_value_prop_backend`` now triggers a ``DeprecationWarning``. The function will be removed in a future release.
+
 **Other changes**
 
 - Propagated values may now be garbage collected if their associated `Var` object goes out of scope. 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,12 +16,13 @@ Change log
 
 **Deprecation**
 
-- Using :func:`spox._future.set_value_prop_backend`` now triggers a ``DeprecationWarning``. The function will be removed in a future release.
+- Using :func:`spox._future.set_value_prop_backend`` with a `spox._future.ValuePropBackend`` now triggers a ``DeprecationWarning``. 
 
 **Other changes**
 
 - Propagated values may now be garbage collected if their associated `Var` object goes out of scope. 
 - :func:`spox.opsets.ai.v17.loop`, :func:`spox.opsets.ai.v19.loop` and :func:`spox.opsets.ai.v21.loop` will only infer shapes for loop carried dependencies if their shapes are unchanged across iterations.
+- Introduced an API to support custom backends for value propagation by extending `spox._future.BaseValuePropBackend``. 
 
 
 0.13.0 (2024-12-06)

--- a/src/spox/__init__.py
+++ b/src/spox/__init__.py
@@ -1,18 +1,10 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import importlib.metadata
 
 from spox._public import argument, build, inline
 from spox._type_system import Optional, Sequence, Tensor, Type
-from spox._value_prop_backend import (
-    OnnxruntimeValuePropBackend,
-    ReferenceValuePropBackend,
-    ValuePropBackend,
-    get_value_prop_backend,
-    set_value_prop_backend,
-    value_prop_backend,
-)
 from spox._var import Var
 
 __all__ = [
@@ -24,12 +16,6 @@ __all__ = [
     "argument",
     "build",
     "inline",
-    "get_value_prop_backend",
-    "set_value_prop_backend",
-    "value_prop_backend",
-    "OnnxruntimeValuePropBackend",
-    "ValuePropBackend",
-    "ReferenceValuePropBackend",
 ]
 
 try:

--- a/src/spox/__init__.py
+++ b/src/spox/__init__.py
@@ -5,6 +5,14 @@ import importlib.metadata
 
 from spox._public import argument, build, inline
 from spox._type_system import Optional, Sequence, Tensor, Type
+from spox._value_prop_backend import (
+    OnnxruntimeValuePropBackend,
+    ReferenceValuePropBackend,
+    ValuePropBackend,
+    get_value_prop_backend,
+    set_value_prop_backend,
+    value_prop_backend,
+)
 from spox._var import Var
 
 __all__ = [
@@ -16,6 +24,12 @@ __all__ = [
     "argument",
     "build",
     "inline",
+    "get_value_prop_backend",
+    "set_value_prop_backend",
+    "value_prop_backend",
+    "OnnxruntimeValuePropBackend",
+    "ValuePropBackend",
+    "ReferenceValuePropBackend",
 ]
 
 try:

--- a/src/spox/_fields.py
+++ b/src/spox/_fields.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/src/spox/_fields.py
+++ b/src/spox/_fields.py
@@ -13,7 +13,7 @@ from typing import Optional, get_type_hints
 from . import _type_system
 from ._attributes import Attr
 from ._exceptions import InferenceWarning
-from ._value_prop import PropValue, PropValueType
+from ._value_prop import PropDict, PropValue
 from ._var import Var, _VarInfo
 
 
@@ -151,7 +151,7 @@ class BaseVarInfos(BaseFields):
             for var in self.get_var_infos().values()
         )
 
-    def into_vars(self, prop_values: dict[str, PropValueType]) -> BaseVars:
+    def into_vars(self, prop_values: PropDict) -> BaseVars:
         """Populate a `BaseVars` object with the propagated values and this object's var_infos"""
 
         def _create_var(key: str, var_info: _VarInfo) -> Var:

--- a/src/spox/_fields.py
+++ b/src/spox/_fields.py
@@ -13,7 +13,7 @@ from typing import Optional, get_type_hints
 from . import _type_system
 from ._attributes import Attr
 from ._exceptions import InferenceWarning
-from ._value_prop import PropDict, PropValue
+from ._value_prop import PropValue, PropValueType
 from ._var import Var, _VarInfo
 
 
@@ -151,7 +151,7 @@ class BaseVarInfos(BaseFields):
             for var in self.get_var_infos().values()
         )
 
-    def into_vars(self, prop_values: PropDict) -> BaseVars:
+    def into_vars(self, prop_values: dict[str, PropValueType]) -> BaseVars:
         """Populate a `BaseVars` object with the propagated values and this object's var_infos"""
 
         def _create_var(key: str, var_info: _VarInfo) -> Var:

--- a/src/spox/_function.py
+++ b/src/spox/_function.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/src/spox/_function.py
+++ b/src/spox/_function.py
@@ -86,10 +86,12 @@ class Function(_InternalNode):
 
         self.func_inputs = self.Inputs(**self.func_args)
         self.func_outputs = self.constructor(
-            self.func_attrs, self.func_inputs.into_vars(input_prop_values)
+            self.func_attrs,
+            self.func_inputs.into_vars(input_prop_values),  # type: ignore
         )
+        # TODO: Implement function propagation
         self.func_graph = _graph.results(
-            **self.func_outputs.into_vars(input_prop_values).flatten_vars()
+            **self.func_outputs.into_vars({}).flatten_vars()
         ).with_arguments(*func_args_var.values())
 
         return {

--- a/src/spox/_function.py
+++ b/src/spox/_function.py
@@ -86,12 +86,10 @@ class Function(_InternalNode):
 
         self.func_inputs = self.Inputs(**self.func_args)
         self.func_outputs = self.constructor(
-            self.func_attrs,
-            self.func_inputs.into_vars(input_prop_values),  # type: ignore
+            self.func_attrs, self.func_inputs.into_vars(input_prop_values)
         )
-        # TODO: Implement function propagation
         self.func_graph = _graph.results(
-            **self.func_outputs.into_vars({}).flatten_vars()
+            **self.func_outputs.into_vars(input_prop_values).flatten_vars()
         ).with_arguments(*func_args_var.values())
 
         return {

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -39,11 +39,19 @@ ValuePropBackend = spox._value_prop.ValuePropBackend
 
 
 def set_value_prop_backend(backend: ValuePropBackend) -> None:
+    warnings.warn(
+        "using '_future.operator_overloading' is deprecated, consider using the stable value propagation instead",
+        DeprecationWarning,
+    )
     spox._value_prop._VALUE_PROP_BACKEND = backend
 
 
 @contextmanager
 def value_prop_backend(backend: ValuePropBackend) -> Iterator[None]:
+    warnings.warn(
+        "using '_future.value_prop_backend' is deprecated, consider using the stable value propagation instead",
+        DeprecationWarning,
+    )
     prev_backend = spox._value_prop._VALUE_PROP_BACKEND
     set_value_prop_backend(backend)
     yield

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -18,6 +18,8 @@ import spox._node
 import spox._value_prop
 from spox._graph import initializer as _initializer
 from spox._type_system import Tensor
+from spox._value_prop import ValuePropBackend
+from spox._value_prop_backend import BaseValuePropBackend
 from spox._var import Var
 
 TypeWarningLevel = spox._node.TypeWarningLevel
@@ -35,35 +37,44 @@ def type_warning_level(level: TypeWarningLevel) -> Iterator[None]:
     set_type_warning_level(prev_level)
 
 
-ValuePropBackend = spox._value_prop.ValuePropBackend
+def set_value_prop_backend(
+    backend: ValuePropBackend | BaseValuePropBackend | None,
+) -> None:
+    if not isinstance(backend, BaseValuePropBackend):
+        warnings.warn(
+            "using '_future.set_value_prop_backend' with a '_future.ValuePropBackend' is deprecated and will be removed in the future",
+            DeprecationWarning,
+        )
 
-
-def set_value_prop_backend(backend: ValuePropBackend) -> None:
-    warnings.warn(
-        "using '_future.set_value_prop_backend' with a '_future.ValuePropBackend' is deprecated and will be removed in the future",
-        DeprecationWarning,
-    )
-    new_backend: spox._value_prop_backend.BaseValuePropBackend | None = None
-
+    new_backend: BaseValuePropBackend | None = None
     if backend == spox._value_prop.ValuePropBackend.REFERENCE:
         new_backend = spox._value_prop_backend.ReferenceValuePropBackend()
     elif backend == spox._value_prop.ValuePropBackend.ONNXRUNTIME:
         new_backend = spox._value_prop_backend.OnnxruntimeValuePropBackend()
+    elif isinstance(backend, BaseValuePropBackend):
+        new_backend = backend
 
     spox._value_prop_backend.set_value_prop_backend(new_backend)
 
 
 @contextmanager
-def value_prop_backend(backend: ValuePropBackend) -> Iterator[None]:
-    warnings.warn(
-        "using '_future.value_prop_backend' with a 'spox._future.ValuePropBackend' is deprecated and will be removed in the future",
-        DeprecationWarning,
-    )
+def value_prop_backend(
+    backend: ValuePropBackend | BaseValuePropBackend | None,
+) -> Iterator[None]:
+    if not isinstance(backend, BaseValuePropBackend):
+        warnings.warn(
+            "using '_future.value_prop_backend' with a 'spox._future.ValuePropBackend' is deprecated and will be removed in the future",
+            DeprecationWarning,
+        )
+
     new_backend: spox._value_prop_backend.BaseValuePropBackend | None = None
     if backend == spox._value_prop.ValuePropBackend.REFERENCE:
         new_backend = spox._value_prop_backend.ReferenceValuePropBackend()
     elif backend == spox._value_prop.ValuePropBackend.ONNXRUNTIME:
         new_backend = spox._value_prop_backend.OnnxruntimeValuePropBackend()
+    elif isinstance(backend, BaseValuePropBackend):
+        new_backend = backend
+
     with spox._value_prop_backend.value_prop_backend(new_backend):
         yield
 
@@ -255,6 +266,7 @@ __all__ = [
     "initializer",
     # Value propagation backend
     "ValuePropBackend",
+    "BaseValuePropBackend",
     "set_value_prop_backend",
     "value_prop_backend",
 ]

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Module containing experimental Spox features that may be standard in the future."""
@@ -44,6 +44,8 @@ def set_value_prop_backend(backend: ValuePropBackend) -> None:
         DeprecationWarning,
     )
     spox._value_prop._VALUE_PROP_BACKEND = backend
+    # For compatibility with the new way of setting a value propagation backend
+    spox._value_prop_backend._VALUE_PROP_BACKEND = None
 
 
 @contextmanager

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -19,7 +19,11 @@ import spox._value_prop
 from spox._graph import initializer as _initializer
 from spox._type_system import Tensor
 from spox._value_prop import ValuePropBackend
-from spox._value_prop_backend import BaseValuePropBackend
+from spox._value_prop_backend import (
+    BaseValuePropBackend,
+    OnnxruntimeValuePropBackend,
+    ReferenceValuePropBackend,
+)
 from spox._var import Var
 
 TypeWarningLevel = spox._node.TypeWarningLevel
@@ -267,6 +271,8 @@ __all__ = [
     # Value propagation backend
     "ValuePropBackend",
     "BaseValuePropBackend",
+    "OnnxruntimeValuePropBackend",
+    "ReferenceValuePropBackend",
     "set_value_prop_backend",
     "value_prop_backend",
 ]

--- a/src/spox/_future.py
+++ b/src/spox/_future.py
@@ -40,24 +40,32 @@ ValuePropBackend = spox._value_prop.ValuePropBackend
 
 def set_value_prop_backend(backend: ValuePropBackend) -> None:
     warnings.warn(
-        "using '_future.operator_overloading' is deprecated, consider using the stable value propagation instead",
+        "using '_future.set_value_prop_backend' with a '_future.ValuePropBackend' is deprecated and will be removed in the future",
         DeprecationWarning,
     )
-    spox._value_prop._VALUE_PROP_BACKEND = backend
-    # For compatibility with the new way of setting a value propagation backend
-    spox._value_prop_backend._VALUE_PROP_BACKEND = None
+    new_backend: spox._value_prop_backend.BaseValuePropBackend | None = None
+
+    if backend == spox._value_prop.ValuePropBackend.REFERENCE:
+        new_backend = spox._value_prop_backend.ReferenceValuePropBackend()
+    elif backend == spox._value_prop.ValuePropBackend.ONNXRUNTIME:
+        new_backend = spox._value_prop_backend.OnnxruntimeValuePropBackend()
+
+    spox._value_prop_backend.set_value_prop_backend(new_backend)
 
 
 @contextmanager
 def value_prop_backend(backend: ValuePropBackend) -> Iterator[None]:
     warnings.warn(
-        "using '_future.value_prop_backend' is deprecated, consider using the stable value propagation instead",
+        "using '_future.value_prop_backend' with a 'spox._future.ValuePropBackend' is deprecated and will be removed in the future",
         DeprecationWarning,
     )
-    prev_backend = spox._value_prop._VALUE_PROP_BACKEND
-    set_value_prop_backend(backend)
-    yield
-    set_value_prop_backend(prev_backend)
+    new_backend: spox._value_prop_backend.BaseValuePropBackend | None = None
+    if backend == spox._value_prop.ValuePropBackend.REFERENCE:
+        new_backend = spox._value_prop_backend.ReferenceValuePropBackend()
+    elif backend == spox._value_prop.ValuePropBackend.ONNXRUNTIME:
+        new_backend = spox._value_prop_backend.OnnxruntimeValuePropBackend()
+    with spox._value_prop_backend.value_prop_backend(new_backend):
+        yield
 
 
 def initializer(value: npt.ArrayLike, dtype: npt.DTypeLike = None) -> Var:

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import itertools

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -142,7 +142,7 @@ class _Inline(_InternalNode):
         ):
             return {}
         input_feed = {
-            i.name: value_prop_backend.wrap_feed(input_prop_values[i.name])
+            i.name: value_prop_backend.wrap_feed(input_prop_values[i.name])  # type: ignore
             for i in self.model.graph.input
             if i.name in input_prop_values
         }

--- a/src/spox/_inline.py
+++ b/src/spox/_inline.py
@@ -142,7 +142,7 @@ class _Inline(_InternalNode):
         ):
             return {}
         input_feed = {
-            i.name: value_prop_backend.wrap_feed(input_prop_values.get(i.name))  # type: ignore
+            i.name: value_prop_backend.wrap_feed(input_prop_values[i.name])
             for i in self.model.graph.input
             if i.name in input_prop_values
         }

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -29,7 +29,7 @@ from ._fields import (
     VarFieldKind,
 )
 from ._type_system import Type
-from ._value_prop import PropDict, PropValueType
+from ._value_prop import PropDict
 from ._var import _VarInfo
 
 if typing.TYPE_CHECKING:
@@ -217,7 +217,7 @@ class Node(ABC):
     def post_init(self, **kwargs: Any) -> None:
         """Post-initialization hook. Called at the end of ``__init__`` after other default fields are set."""
 
-    def propagate_values(self, input_prop_values: PropDict) -> dict[str, PropValueType]:
+    def propagate_values(self, input_prop_values: PropDict) -> PropDict:
         """
         Propagate values from inputs, and, if possible, compute values for outputs as well.
         This method is used to implement ONNX partial data propagation - for example so that

--- a/src/spox/_node.py
+++ b/src/spox/_node.py
@@ -29,7 +29,7 @@ from ._fields import (
     VarFieldKind,
 )
 from ._type_system import Type
-from ._value_prop import PropDict
+from ._value_prop import PropDict, PropValueType
 from ._var import _VarInfo
 
 if typing.TYPE_CHECKING:
@@ -217,7 +217,7 @@ class Node(ABC):
     def post_init(self, **kwargs: Any) -> None:
         """Post-initialization hook. Called at the end of ``__init__`` after other default fields are set."""
 
-    def propagate_values(self, input_prop_values: PropDict) -> PropDict:
+    def propagate_values(self, input_prop_values: PropDict) -> dict[str, PropValueType]:
         """
         Propagate values from inputs, and, if possible, compute values for outputs as well.
         This method is used to implement ONNX partial data propagation - for example so that

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -312,7 +312,7 @@ def inline(model: onnx.ModelProto) -> _InlineCall:
         )
 
         prop_values: PropDict = {
-            name: kwargs[name]._value  # type: ignore
+            name: kwargs[name]._value
             for name in in_names
             if kwargs[name]._value is not None
         }

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -312,7 +312,7 @@ def inline(model: onnx.ModelProto) -> _InlineCall:
         )
 
         prop_values: PropDict = {
-            name: kwargs[name]._value
+            name: kwargs[name]._value  # type: ignore
             for name in in_names
             if kwargs[name]._value is not None
         }

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Module implementing the main public interface functions in Spox."""

--- a/src/spox/_standard.py
+++ b/src/spox/_standard.py
@@ -207,7 +207,7 @@ class StandardNode(Node):
             with_dummy_subgraphs=False, input_prop_values=input_prop_values
         )
         input_feed = {
-            scope.var[var_info]: value_prop_backend.wrap_feed(input_prop_values[name])
+            scope.var[var_info]: value_prop_backend.wrap_feed(input_prop_values[name])  # type: ignore
             for name, var_info in self.inputs.get_var_infos().items()
             if input_prop_values[name]
         }

--- a/src/spox/_standard.py
+++ b/src/spox/_standard.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Module implementing a base for standard ONNX operators, which use the functionality of ONNX node-level inference."""

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import enum

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -21,7 +21,7 @@ The internal representation for runtime values.
 - None -> Optional, Nothing (no value)
 """
 PropValueType = Union[np.ndarray, list["PropValue"], "PropValue", None]
-PropDict = dict[str, "PropValue"]
+PropDict = dict[str, "PropValueType"]
 ORTValue = Union[np.ndarray, list, None]
 RefValue = Union[np.ndarray, list, float, None]
 

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -21,7 +21,7 @@ The internal representation for runtime values.
 - None -> Optional, Nothing (no value)
 """
 PropValueType = Union[np.ndarray, list["PropValue"], "PropValue", None]
-PropDict = dict[str, "PropValueType"]
+PropDict = dict[str, PropValueType]
 ORTValue = Union[np.ndarray, list, None]
 RefValue = Union[np.ndarray, list, float, None]
 

--- a/src/spox/_value_prop_backend.py
+++ b/src/spox/_value_prop_backend.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 

--- a/src/spox/_value_prop_backend.py
+++ b/src/spox/_value_prop_backend.py
@@ -1,0 +1,122 @@
+# Copyright (c) QuantCo 2023-2024
+# SPDX-License-Identifier: BSD-3-Clause
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+import onnx
+
+from . import _value_prop
+from ._type_system import Type
+from ._value_prop import ORTValue, PropValue, RefValue
+
+if TYPE_CHECKING:
+    pass
+
+TValue = TypeVar("TValue")
+
+
+class BaseValuePropBackend(ABC, Generic[TValue]):
+    @abstractmethod
+    def wrap_feed(self, value: PropValue) -> TValue:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run(
+        self, model: onnx.ModelProto, input_feed: dict[str, TValue]
+    ) -> dict[str, TValue]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def unwrap_feed(self, typ: Type, value: TValue) -> PropValue:
+        raise NotImplementedError
+
+
+class ReferenceValuePropBackend(BaseValuePropBackend[RefValue]):
+    def wrap_feed(self, value: PropValue) -> RefValue:
+        return value.to_ref_value()
+
+    def run(
+        self, model: onnx.ModelProto, input_feed: dict[str, RefValue]
+    ) -> dict[str, RefValue]:
+        try:
+            session = onnx.reference.ReferenceEvaluator(model)
+            output_feed = dict(zip(session.output_names, session.run(None, input_feed)))
+        except Exception as e:
+            # Give up on value propagation if an implementation is missing.
+            logging.debug(
+                f"Value propagation in {model} on the ONNX reference implementation failed with - "
+                f"{type(e).__name__}: {e}"
+            )
+            return {}
+        return output_feed
+
+    def unwrap_feed(self, typ: Type, value: RefValue) -> PropValue:
+        return PropValue.from_ref_value(typ, value)
+
+
+class OnnxruntimeValuePropBackend(BaseValuePropBackend[ORTValue]):
+    def __init__(self, session_options: dict[str, Any] | None = None) -> None:
+        import onnxruntime
+
+        self.session_options = onnxruntime.SessionOptions()
+
+        if session_options is None:
+            session_options = {"log_severity_level": 3}
+
+        for opt, val in session_options.items():
+            setattr(self.session_options, opt, val)
+
+    def wrap_feed(self, value: PropValue) -> ORTValue:
+        return value.to_ort_value()
+
+    def run(
+        self, model: onnx.ModelProto, input_feed: dict[str, ORTValue]
+    ) -> dict[str, ORTValue]:
+        import onnxruntime
+
+        try:
+            session = onnxruntime.InferenceSession(
+                model.SerializeToString(), self.session_options
+            )
+            output_names = [output.name for output in session.get_outputs()]
+            output_feed = dict(zip(output_names, session.run(None, input_feed)))
+        except Exception as e:
+            logging.debug(
+                f"Value propagation in {model} on the onnxruntime failed with - "
+                f"{type(e).__name__}: {e}"
+            )
+            return {}
+        return output_feed
+
+    def unwrap_feed(self, typ: Type, value: ORTValue) -> PropValue:
+        return PropValue.from_ref_value(typ, value)
+
+
+_VALUE_PROP_BACKEND: BaseValuePropBackend | None = ReferenceValuePropBackend()
+
+
+def get_value_prop_backend() -> BaseValuePropBackend | None:
+    if _VALUE_PROP_BACKEND is not None:
+        return _VALUE_PROP_BACKEND
+    elif _value_prop._VALUE_PROP_BACKEND == _value_prop._VALUE_PROP_BACKEND.REFERENCE:
+        return ReferenceValuePropBackend()
+    elif _value_prop._VALUE_PROP_BACKEND == _value_prop._VALUE_PROP_BACKEND.ONNXRUNTIME:
+        return OnnxruntimeValuePropBackend()
+    return None
+
+
+def set_value_prop_backend(backend: BaseValuePropBackend | None) -> None:
+    _VALUE_PROP_BACKEND = backend
+
+
+@contextmanager
+def value_prop_backend(backend: BaseValuePropBackend | None) -> Iterator[None]:
+    prev_backend = _VALUE_PROP_BACKEND
+    set_value_prop_backend(backend)
+    yield
+    set_value_prop_backend(prev_backend)

--- a/src/spox/_value_prop_backend.py
+++ b/src/spox/_value_prop_backend.py
@@ -10,7 +10,6 @@ from typing import Generic, TypeVar
 
 import onnx
 
-from . import _value_prop
 from ._type_system import Type
 from ._value_prop import ORTValue, PropValue, RefValue
 
@@ -89,13 +88,7 @@ _VALUE_PROP_BACKEND: BaseValuePropBackend | None = ReferenceValuePropBackend()
 
 
 def get_value_prop_backend() -> BaseValuePropBackend | None:
-    if _VALUE_PROP_BACKEND is not None:
-        return _VALUE_PROP_BACKEND
-    elif _value_prop._VALUE_PROP_BACKEND == _value_prop._VALUE_PROP_BACKEND.REFERENCE:
-        return ReferenceValuePropBackend()
-    elif _value_prop._VALUE_PROP_BACKEND == _value_prop._VALUE_PROP_BACKEND.ONNXRUNTIME:
-        return OnnxruntimeValuePropBackend()
-    return None
+    return _VALUE_PROP_BACKEND
 
 
 def set_value_prop_backend(backend: BaseValuePropBackend | None) -> None:

--- a/src/spox/_value_prop_backend.py
+++ b/src/spox/_value_prop_backend.py
@@ -111,6 +111,7 @@ def get_value_prop_backend() -> BaseValuePropBackend | None:
 
 
 def set_value_prop_backend(backend: BaseValuePropBackend | None) -> None:
+    global _VALUE_PROP_BACKEND
     _VALUE_PROP_BACKEND = backend
 
 

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -374,8 +374,4 @@ def create_prop_dict(
 
     flattened_vars = BaseVars(kwargs).flatten_vars()
 
-    return {
-        key: var._value
-        for key, var in flattened_vars.items()
-        if var is not None and var._value is not None
-    }
+    return {key: var._value for key, var in flattened_vars.items() if var is not None}

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -374,4 +374,8 @@ def create_prop_dict(
 
     flattened_vars = BaseVars(kwargs).flatten_vars()
 
-    return {key: var._value for key, var in flattened_vars.items() if var is not None}
+    return {
+        key: var._value
+        for key, var in flattened_vars.items()
+        if var is not None and var._value is not None
+    }

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -21,6 +21,8 @@ from spox._var import _VarInfo
     params=[
         spox._future.ValuePropBackend.ONNXRUNTIME,
         spox._future.ValuePropBackend.REFERENCE,
+        spox._future.ReferenceValuePropBackend,
+        spox._future.OnnxruntimeValuePropBackend,
     ]
 )
 def value_prop_backend(request):


### PR DESCRIPTION
Duplicate of #201 because of missing access to the repo

Since we currently "bless" the reference and onnxruntime implementations as the only way to propagate value internally, this PR refactors a bit the internals to allow a better interface for "custom" execution providers(i.e. @cbourjau rust runtime, onnx-mlir...). 
Consult the [tests](https://github.com/Quantco/spox/pull/201/files#diff-4fd3c1127443dc7813c4d2f5f6be9428b706028bf55bd72e11132635de73394fR239) for a POC which could also be used to register custom opsets as well.

# Checklist

- [X] Added a `CHANGELOG.rst` entry
