### PR TITLE
Don't run publishing action on tag and release

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -2,10 +2,10 @@ name: Build and upload to PyPI
 
 on:
   push:
-  pull_request:
-  release:
-    types:
-      - published
+    branches:
+      - "*"
+    tags:
+      - "*"
 
 jobs:
   build:


### PR DESCRIPTION
I think this is the reason for the failed job with the latest release: https://github.com/Quantco/spox/actions/runs/15485498971/job/43599168210#step:3:164

