### PR TITLE
Remove unnecessary and costly calls to typing.get_type_hints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.17.1 (2026-02-17)
+-------------------
+
+**Performance**
+
+- Removed unnecessary and costly calls to ``typing.get_type_hints``.
+
+
 0.17.0 (2026-01-13)
 -------------------
 

--- a/src/spox/_build.py
+++ b/src/spox/_build.py
@@ -165,8 +165,8 @@ class Builder:
     graphs: set[Graph]
     graph_topo: list[Graph]
     # Arguments, results
-    arguments_of: dict[Graph, list[_VarInfo]]
-    results_of: dict[Graph, list[_VarInfo]]
+    arguments_of: dict[Graph, tuple[_VarInfo, ...]]
+    results_of: dict[Graph, tuple[_VarInfo, ...]]
     source_of: dict[Graph, Node]
     # Arguments found by traversal
     all_arguments_in: dict[Graph, set[_VarInfo]]
@@ -287,7 +287,7 @@ class Builder:
         # Now we resolve which arguments we should get.
         if graph.requested_arguments is None:
             # If there's no request, we take all arguments found anywhere in this graph
-            self.arguments_of[graph] = list(all_arguments - claimed_arguments)
+            self.arguments_of[graph] = tuple(all_arguments - claimed_arguments)
         else:
             # If there is a request, we may not have found it by traversal if an argument was unused.
             all_arguments |= set(unwrap_vars(graph.requested_arguments))

--- a/src/spox/_public.py
+++ b/src/spox/_public.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2025
+# Copyright (c) QuantCo 2023-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 """Module implementing the main public interface functions in Spox."""

--- a/src/spox/_var.py
+++ b/src/spox/_var.py
@@ -333,11 +333,11 @@ def unwrap_vars(var: Var | None) -> _VarInfo | None: ...
 
 
 @overload
-def unwrap_vars(var: dict[T, Var]) -> dict[T, _VarInfo]: ...  # type: ignore[overload-overlap]
+def unwrap_vars(var: dict[str, Var]) -> dict[str, _VarInfo]: ...
 
 
 @overload
-def unwrap_vars(var: Iterable[Var]) -> list[_VarInfo]: ...
+def unwrap_vars(var: Iterable[Var]) -> tuple[_VarInfo, ...]: ...
 
 
 def unwrap_vars(var):  # type: ignore
@@ -348,7 +348,7 @@ def unwrap_vars(var):  # type: ignore
     elif isinstance(var, dict):
         return {k: unwrap_vars(v) for k, v in var.items()}
     elif isinstance(var, Iterable):
-        return [unwrap_vars(v) for v in var]
+        return tuple(unwrap_vars(v) for v in var)
     else:
         raise ValueError("Unsupported type for unwrap_vars")
 

--- a/tests/test_custom_operator.py
+++ b/tests/test_custom_operator.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2025
+# Copyright (c) QuantCo 2023-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 """


### PR DESCRIPTION
Profiling the construction of fairly large graphs by @SamuelLessmannQC found that we spend a considerable fraction of the run time in `typing.get_type_hints`. This PR refactors the code in a minimally invasive way to remove unnecessary calls to that function.

On a larger picture, I'd like to refactor this code for a very long time, but that is on an equally low priority. As it stands right now, each `Node` has an associated `Inputs` and `Outputs` type. The machinery around those is fairly complex, but ultimately performs only some simple validations. Alas, things work splendidly, so I don't think this is the day to make a larger refactor.

# Checklist

- [x] Added a `CHANGELOG.rst` entry
