### PR TITLE
Disable mitigation for bug in onnxruntime CSE triggered during value propagation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Change log
 ==========
 
+0.17.2 (2026-06-04)
+-------------------
+
+**Other change**
+
+- Disable onnxruntime optimization passes in value propagation as a mitigation for https://github.com/microsoft/onnxruntime/issues/28413 and to speed-up session creation.
+
+
 0.17.1 (2026-02-17)
 -------------------
 

--- a/src/spox/_value_prop.py
+++ b/src/spox/_value_prop.py
@@ -146,13 +146,14 @@ def _run_reference_implementation(
 def _run_onnxruntime(
     model: onnx.ModelProto, input_feed: dict[str, ORTValue]
 ) -> dict[str, ORTValue]:
-    import onnxruntime
+    import onnxruntime as ort
 
     # Silence possible warnings during execution (especially constant folding)
-    options = onnxruntime.SessionOptions()
+    options = ort.SessionOptions()
     options.log_severity_level = 3
+    options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
     try:
-        session = onnxruntime.InferenceSession(model.SerializeToString(), options)
+        session = ort.InferenceSession(model.SerializeToString(), options)
         output_names = [output.name for output in session.get_outputs()]
         output_feed = dict(zip(output_names, session.run(None, input_feed)))
     except Exception as e:

--- a/tests/test_value_propagation.py
+++ b/tests/test_value_propagation.py
@@ -9,7 +9,7 @@ import pytest
 
 import spox
 import spox._future
-import spox.opset.ai.onnx.ml.v3 as ml
+import spox.opset.ai.onnx.ml.v4 as ml
 import spox.opset.ai.onnx.v22 as op
 from spox import Optional, Sequence, Tensor, Type, Var, argument
 from spox._graph import arguments, results
@@ -259,3 +259,17 @@ def test_strings():
 
     x, y = op.const(["foo"]), op.const(["bar"])
     np.testing.assert_equal(op.string_concat(x, y)._value.value, np.array(["foobar"]))  # type: ignore
+
+
+def test_value_prop_ort_cse_bug_mitigation():
+    """Test mitigation against ort CSE crash."""
+    # A constant string input so value propagation actually runs.
+    x = op.const(np.array(["a"], dtype=np.str_))
+
+    y = ml.label_encoder(
+        x,
+        keys_tensor=np.array(["a"], dtype=np.str_),
+        values_tensor=np.array(["b"], dtype=np.str_),
+        default_tensor=np.array(["MISSING"], dtype=np.str_),
+    )
+    assert y._value is not None


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime/issues/28413 contains more information about the upstream bug. It is fixed on the main, but not released yet. The mitigation is to disable optimization passes for value propagation, which seems sensical, given that there is not much to optimize on those tiny graphs. 

# Checklist

- [x] Added a `CHANGELOG.rst` entry
